### PR TITLE
feat(pokeinfo): add speed stat lines to command response

### DIFF
--- a/src/commands/pokeinfo.ts
+++ b/src/commands/pokeinfo.ts
@@ -12,6 +12,7 @@ import {
 import { bold } from '../discord/utils';
 import {
   formatBaseStats,
+  formatSpeedLines,
   getAllPokemonNames,
   searchPokemonByName,
 } from '../pokeinfo';
@@ -53,6 +54,7 @@ export async function createResponse(
       `${bold(name)} の情報ロト！`,
       `${data.types.join('・')} ${formatBaseStats(data.baseStats)}`,
       `特性: ${data.abilities.join(' / ')}`,
+      formatSpeedLines(data.baseStats.S),
     ];
     if (data.yakkun?.url) {
       lines.push(data.yakkun.url);

--- a/src/pokeinfo/index.test.ts
+++ b/src/pokeinfo/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { getAllPokemonNames, searchPokemonByName } from './index';
+import {
+  formatSpeedLines,
+  getAllPokemonNames,
+  searchPokemonByName,
+} from './index';
 
 describe('searchPokemonByName', () => {
   test('returns pokemon data for a valid name', async () => {
@@ -20,6 +24,26 @@ describe('searchPokemonByName', () => {
     const result = await searchPokemonByName('メガリザードンＸ');
     expect(result).not.toBeNull();
     expect(result!.yakkun?.key).toBe('n6x');
+  });
+});
+
+describe('formatSpeedLines', () => {
+  test('calculates speed lines for base speed 65 (ニャオハ)', () => {
+    const result = formatSpeedLines(65);
+    // 最遅: floor((floor((130+31)*50/100)+5)*0.9) = floor(85*0.9) = 76
+    // 無振り: floor((80+5)*1.0) = 85
+    // 準速: floor((floor((130+31+63)*50/100)+5)*1.0) = floor(112+5) = 117
+    // 最速: floor(117*1.1) = 128
+    expect(result).toBe('S実数値: 最遅76 / 無振り85 / 準速117 / 最速128');
+  });
+
+  test('calculates speed lines for base speed 136 (テツノツツミ)', () => {
+    const result = formatSpeedLines(136);
+    // 最遅: floor((floor((272+31)*50/100)+5)*0.9) = floor((151+5)*0.9) = floor(140.4) = 140
+    // 無振り: floor((151+5)*1.0) = 156
+    // 準速: floor((floor((272+31+63)*50/100)+5)*1.0) = floor(183+5) = 188
+    // 最速: floor(188*1.1) = floor(206.8) = 206
+    expect(result).toBe('S実数値: 最遅140 / 無振り156 / 準速188 / 最速206');
   });
 });
 

--- a/src/pokeinfo/index.ts
+++ b/src/pokeinfo/index.ts
@@ -49,6 +49,15 @@ export function formatBaseStats(baseStats: {
   return `${baseStats.H}-${baseStats.A}-${baseStats.B}-${baseStats.C}-${baseStats.D}-${baseStats.S}`;
 }
 
+export function formatSpeedLines(baseS: number): string {
+  const calc = (ev: number, nature: number) =>
+    Math.floor(
+      (Math.floor(((2 * baseS + 31 + Math.floor(ev / 4)) * 50) / 100) + 5) *
+        nature,
+    );
+  return `S実数値: 最遅${calc(0, 0.9)} / 無振り${calc(0, 1.0)} / 準速${calc(252, 1.0)} / 最速${calc(252, 1.1)}`;
+}
+
 /**
  * カタカナをひらがなに変換する
  */


### PR DESCRIPTION
## Summary
- pokeinfoコマンドのレスポンスに素早さ実数値ライン（Lv50・IV31）を追加
- 最遅（下降補正）/ 無振り（無補正）/ 準速（無補正252振り）/ 最速（上昇補正252振り）の4値を表示

## Test plan
- [x] `formatSpeedLines` のユニットテスト追加（S65, S136）
- [ ] `pnpm test` / `pnpm typecheck` / `pnpm lint` がCIで通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)