### PR TITLE
feat(pokeinfo): display base stats as ASCII bar chart

### DIFF
--- a/src/commands/pokeinfo.ts
+++ b/src/commands/pokeinfo.ts
@@ -11,7 +11,7 @@ import {
 } from 'discord-api-types/v10';
 import { bold } from '../discord/utils';
 import {
-  formatBaseStats,
+  formatBaseStatsGraph,
   formatSpeedLines,
   getAllPokemonNames,
   searchPokemonByName,
@@ -51,10 +51,10 @@ export async function createResponse(
   if (data) {
     console.log(`[pokeinfo] found pokemon: ${data.yakkun?.url ?? name}`);
     const lines = [
-      `${bold(name)} の情報ロト！`,
-      `${data.types.join('・')} ${formatBaseStats(data.baseStats)}`,
-      `特性: ${data.abilities.join(' / ')}`,
+      `${bold(name)} の情報ロト！ ${data.types.join('・')}`,
+      formatBaseStatsGraph(data.baseStats),
       formatSpeedLines(data.baseStats.S),
+      `特性: ${data.abilities.join(' / ')}`,
     ];
     if (data.yakkun?.url) {
       lines.push(data.yakkun.url);

--- a/src/pokeinfo/index.test.ts
+++ b/src/pokeinfo/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  formatBaseStatsGraph,
   formatSpeedLines,
   getAllPokemonNames,
   searchPokemonByName,
@@ -44,6 +45,46 @@ describe('formatSpeedLines', () => {
     // 準速: floor((floor((272+31+63)*50/100)+5)*1.0) = floor(183+5) = 188
     // 最速: floor(188*1.1) = floor(206.8) = 206
     expect(result).toBe('S実数値: 最遅140 / 無振り156 / 準速188 / 最速206');
+  });
+});
+
+describe('formatBaseStatsGraph', () => {
+  test('formats stats as bar chart in code block', () => {
+    const result = formatBaseStatsGraph({
+      H: 40,
+      A: 61,
+      B: 56,
+      C: 62,
+      D: 63,
+      S: 65,
+    });
+    expect(result).toBe(
+      '```\n' +
+        'H |===               |  40\n' +
+        'A |====              |  61\n' +
+        'B |====              |  56\n' +
+        'C |====              |  62\n' +
+        'D |====              |  63\n' +
+        'S |=====             |  65\n' +
+        '```',
+    );
+  });
+
+  test('scales bars correctly for extreme values', () => {
+    const result = formatBaseStatsGraph({
+      H: 255,
+      A: 0,
+      B: 128,
+      C: 1,
+      D: 200,
+      S: 100,
+    });
+    expect(result).toContain('H |==================| 255');
+    expect(result).toContain('A |                  |   0');
+    expect(result).toContain('B |=========         | 128');
+    expect(result).toContain('C |                  |   1');
+    expect(result).toContain('D |==============    | 200');
+    expect(result).toContain('S |=======           | 100');
   });
 });
 

--- a/src/pokeinfo/index.ts
+++ b/src/pokeinfo/index.ts
@@ -37,16 +37,26 @@ export async function getAllPokemonNames(params: {
   });
 }
 
-export function formatBaseStats(baseStats: {
-  H: number;
-  A: number;
-  B: number;
-  C: number;
-  D: number;
-  S: number;
-}) {
-  // join stats as H-A-B-C-D-S
-  return `${baseStats.H}-${baseStats.A}-${baseStats.B}-${baseStats.C}-${baseStats.D}-${baseStats.S}`;
+const STAT_KEYS: (keyof Pokemon['baseStats'])[] = [
+  'H',
+  'A',
+  'B',
+  'C',
+  'D',
+  'S',
+];
+
+const MAX_STAT = 255;
+const BAR_WIDTH = 18;
+
+export function formatBaseStatsGraph(baseStats: Pokemon['baseStats']): string {
+  const lines = STAT_KEYS.map((key) => {
+    const value = baseStats[key];
+    const barLen = Math.round((value / MAX_STAT) * BAR_WIDTH);
+    const bar = '='.repeat(barLen) + ' '.repeat(BAR_WIDTH - barLen);
+    return `${key} |${bar}| ${value.toString().padStart(3)}`;
+  });
+  return '```\n' + lines.join('\n') + '\n```';
 }
 
 export function formatSpeedLines(baseS: number): string {


### PR DESCRIPTION
## Summary
- 種族値のインライン表示（`H-A-B-C-D-S`）をASCIIバーチャートに変更
- Discordコードブロック内で等幅フォントによる崩れない表示を実現
- 情報の並び順を近接の原則に基づき整理（名前+タイプ → 種族値グラフ → S実数値 → 特性 → URL）

## Test plan
- [x] `formatBaseStatsGraph` の単体テスト追加済み（通常値・極端値）
- [x] typecheck / lint / test 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)