### PR TITLE
fix: add nodejs_compat flag for cli-table3 dependency

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,5 @@
 compatibility_date = "2023-09-17"
+compatibility_flags = ["nodejs_compat"]
 main = "src/index.ts"
 name = "discord-rotom-bot"
 


### PR DESCRIPTION
## Summary
- cli-table3の依存先@colors/colorsがNode.js組み込みモジュール(os)を使用するため、Cloudflare Workersのnodejs_compatフラグを有効化

## Test plan
- [x] デプロイが成功すること