### PR TITLE
fix: update compatibility_date and add deploy-check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,18 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test
 
+  deploy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: npx wrangler deploy --dry-run --outdir dist
+
   renovate-review:
     if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
@@ -152,6 +164,7 @@ jobs:
       - lint
       - typecheck
       - test
+      - deploy-check
       - renovate-review
       - code-review
     runs-on: ubuntu-latest

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-compatibility_date = "2023-09-17"
+compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 main = "src/index.ts"
 name = "discord-rotom-bot"


### PR DESCRIPTION
## Summary
- `compatibility_date`を`2024-09-23`に更新し、`nodejs_compat`でNode.js組み込みモジュール(os/util)を正しく解決
- CIに`deploy-check`ジョブ(`wrangler deploy --dry-run`)を追加し、デプロイ互換性をマージ前に検証

## Test plan
- [x] ローカルで`wrangler deploy --dry-run`成功確認済み
- [x] CIのdeploy-checkジョブが通ること
- [x] マージ後のデプロイが成功すること