### PR TITLE
fix(pokeinfo): simplify BST label

### DIFF
--- a/src/pokeinfo/embed.test.ts
+++ b/src/pokeinfo/embed.test.ts
@@ -39,7 +39,7 @@ describe('formatPokemonEmbed', () => {
           {
             "inline": false,
             "name": "種族値",
-            "value": "56-80-114-124-60-136 (合計 570)",
+            "value": "56-80-114-124-60-136 (570)",
           },
           {
             "inline": true,
@@ -107,7 +107,7 @@ describe('formatPokemonEmbed', () => {
           {
             "inline": false,
             "name": "種族値",
-            "value": "70-45-48-60-65-35 (合計 323)",
+            "value": "70-45-48-60-65-35 (323)",
           },
           {
             "inline": true,
@@ -175,7 +175,7 @@ describe('formatPokemonEmbed', () => {
           {
             "inline": false,
             "name": "種族値",
-            "value": "78-130-111-130-85-100 (合計 634)",
+            "value": "78-130-111-130-85-100 (634)",
           },
           {
             "inline": true,

--- a/src/pokeinfo/embed.ts
+++ b/src/pokeinfo/embed.ts
@@ -33,7 +33,7 @@ function buildBaseStatsField(data: PokemonViewModel): APIEmbedField {
   const values = data.stats.map((s) => s.base).join('-');
   return {
     name: '種族値',
-    value: `${values} (合計 ${data.bst})`,
+    value: `${values} (${data.bst})`,
     inline: false,
   };
 }


### PR DESCRIPTION
## Summary
- 種族値の合計表記を `(合計 570)` → `(570)` に簡略化

## Test plan
- [x] all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)