### PR TITLE
feat(pokeinfo): add pokemon thumbnail to embed

### DIFF
--- a/src/pokeinfo/embed.test.ts
+++ b/src/pokeinfo/embed.test.ts
@@ -77,6 +77,9 @@ describe('formatPokemonEmbed', () => {
             "value": "https://yakkun.com/ch/zukan/n991",
           },
         ],
+        "thumbnail": {
+          "url": "https://img.yakkun.com/sprites/home/n991.png",
+        },
         "title": "テツノツツミ の情報ロト！",
       }
     `);
@@ -145,6 +148,9 @@ describe('formatPokemonEmbed', () => {
             "value": "https://yakkun.com/ch/zukan/n35",
           },
         ],
+        "thumbnail": {
+          "url": "https://img.yakkun.com/sprites/home/n35.png",
+        },
         "title": "ピッピ の情報ロト！",
       }
     `);
@@ -213,6 +219,9 @@ describe('formatPokemonEmbed', () => {
             "value": "https://yakkun.com/ch/zukan/n6x",
           },
         ],
+        "thumbnail": {
+          "url": "https://img.yakkun.com/sprites/home/n6x.png",
+        },
         "title": "メガリザードンＸ の情報ロト！",
       }
     `);

--- a/src/pokeinfo/embed.ts
+++ b/src/pokeinfo/embed.ts
@@ -73,5 +73,8 @@ export function formatPokemonEmbed(data: PokemonViewModel): APIEmbed {
     title: `${data.name} の情報ロト！`,
     color,
     fields,
+    ...(data.yakkunImageUrl && {
+      thumbnail: { url: data.yakkunImageUrl },
+    }),
   };
 }

--- a/src/pokeinfo/view-model.ts
+++ b/src/pokeinfo/view-model.ts
@@ -30,6 +30,7 @@ export type PokemonViewModel = {
   stats: StatActuals[];
   bst: number;
   yakkunUrl?: string;
+  yakkunImageUrl?: string;
 };
 
 export function buildPokemonViewModel(
@@ -56,5 +57,8 @@ export function buildPokemonViewModel(
     stats,
     bst,
     yakkunUrl: pokemon.yakkun?.url,
+    yakkunImageUrl: pokemon.yakkun
+      ? `https://img.yakkun.com/sprites/home/${pokemon.yakkun.key}.png`
+      : undefined,
   };
 }


### PR DESCRIPTION
## Summary
- pokeinfoコマンドのEmbed右上にポケモン画像をサムネイル表示
- yakkun.comのOGP画像URL（`img.yakkun.com/sprites/home/{key}.png`）を利用
- yakkun URLがないポケモンはサムネイルなし（従来通り）

## Test plan
- [x] 既存テスト全パス
- [x] typecheck通過
- [ ] デプロイ後、pokeinfoコマンドで画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)