### PR TITLE
feat(pokeinfo): ephemeral preview with share-to-channel button

### DIFF
--- a/docs/0001-pokeinfo-share-button.md
+++ b/docs/0001-pokeinfo-share-button.md
@@ -1,0 +1,169 @@
+# pokeinfo コマンド: 2段階レスポンス（プレビュー→シェア）
+
+- Status: Draft
+- Author: lacolaco
+- Date: 2026-04-23
+
+## 背景
+
+現在 `/pokeinfo` は実行と同時にチャンネルに公開 embed を投稿する。検索結果が意図通りでなかった場合（名前の打ち間違い、同名フォームの選択ミスなど）でも取り消せず、ノイズがそのまま残る。
+
+## ゴール
+
+- `/pokeinfo` の検索結果を、まず呼び出したユーザー本人にだけ見える ephemeral メッセージとして返す。
+- ephemeral に「チャンネルに共有」ボタンを付け、押下時に同じ embed を public メッセージとして投稿する。
+- 共有後は ephemeral からボタンを消し、二重共有を防ぐ。
+
+## 非ゴール
+
+- `ping` などその他のコマンドの挙動変更。
+- 検索結果が見つからなかった場合のフロー変更（従来通り ephemeral で完結、ボタンなし）。
+- 編集機能・フォーム選択 UI の追加（別スコープ）。
+- shared message への「取り消す」ボタンの追加（Discord の通常の削除 UI で十分）。
+
+## ユーザー体験
+
+1. ユーザーが `/pokeinfo name:ピカチュウ` を実行。
+2. Bot は ephemeral メッセージで embed + 「チャンネルに共有」ボタンを返す。
+3. ユーザーが embed を確認し、意図通りなら「チャンネルに共有」を押す。
+4. 同じ embed がチャンネルに公開メッセージとして投稿される。ephemeral は「共有しました」などに更新されボタンは消える。
+5. 意図と違ったら押さずに放置すればよい（ephemeral は本人にしか見えず、時間経過で Discord クライアント上から自動的に消える）。
+
+検索失敗時（"見つからなかったロトね..." のケース）は ephemeral で完結し、ボタンを表示しない。
+
+## 技術設計
+
+### Discord インタラクションフロー
+
+```
+[User] /pokeinfo name:ピカチュウ
+   │
+   ▼
+[Bot] InteractionResponseType.ChannelMessageWithSource
+      data: { embeds: [embed], components: [Button], flags: Ephemeral(64) }
+   │
+[User] ボタン押下
+   │
+   ▼
+[Discord] MessageComponent interaction (type=3) を Bot に送信
+          custom_id = "pokeinfo:share:ピカチュウ"
+   │
+   ▼
+[Bot] Response: InteractionResponseType.UpdateMessage
+      data: { content: '共有しました', embeds: [], components: [] }
+      （ephemeral メッセージを置き換え、ボタンを消す）
+   │
+[Bot] Followup webhook (ctx.waitUntil で非同期):
+      POST /webhooks/{app_id}/{interaction_token}
+      body: { embeds: [embed] }  // flags なし → 公開メッセージ
+```
+
+- ボタン押下時の Discord 仕様: `UPDATE_MESSAGE` (type 7) は押されたメッセージ（ephemeral）を編集する。一方、同じ interaction_token で `POST /webhooks/{app_id}/{token}` を叩くと「チャンネルへの新規投稿」になる。この 2 つを組み合わせる。
+- `ctx.waitUntil` は Hono の `c.executionCtx.waitUntil` 経由で取得できる。fetch handler は 3 秒以内に応答を返す必要があるため、followup 投稿は非同期化する。
+
+### custom_id 設計
+
+フォーマット: `pokeinfo:share:<ポケモン日本語名>`
+
+例: `pokeinfo:share:ピカチュウ`、`pokeinfo:share:メガフシギバナ`
+
+- 命名: `<namespace>:<action>:<payload>` のコロン区切り。`pokeinfo` namespace は将来の他アクション（例: フォーム切替）も同 prefix で受けられる。
+- 識別子の選定: ポケモン日本語名を採用。このプロジェクトの primary key は日本語名で、`data.generated.json` のオブジェクトキー・`searchPokemonByName` の引数・autocomplete 返り値すべてに一貫して使われている。外部データソース非依存で、プロジェクト固有の安定した識別子。
+  - `yakkun.key` は外部サイト（yakkun.com）の URL スラッグであり、このボットの primary key ではない。yakkun 依存を外した将来に意味を失うため不採用。
+  - Showdown ID（`pikachu` 等）は ASCII だが現データに含まれず、参照のための追加コスト（`@pkmn/dex` 依存）が発生する。
+  - ビルド時に内部 ID を付与するのはパイプライン改修が必要で過剰。
+- 安全性検証:
+  - 全 1235 エントリで `:` を含むキーはゼロ（デリミタ衝突なし）。
+  - 最大長 23 文字、Discord custom_id 上限 100 文字に余裕。
+  - サロゲートペア・制御文字なし。`♀♂` は Discord が問題なく扱える Unicode。
+  - custom_id は Interaction JSON body で往復するため URL エンコード不要。
+- 認可: ephemeral メッセージは呼び出し元ユーザーにしか表示されないため、他人がボタンを押下することは物理的に不可能。`user_id` の埋め込み・照合は不要。
+- 状態保存: KV や DB を使わない。全情報を custom_id に載せる（stateless）。これにより Worker の複数インスタンスでも一貫動作する。
+- パース: `custom_id.split(':')` の 3 番目以降を `:` で再結合（将来ペイロードに `:` が紛れ込んでも対応できる）。現状は 3 セグメントで十分。
+
+### ルーティング
+
+現状の `handleInteractionRequest` (src/discord/interactions.ts:33) は `ApplicationCommand` と `ApplicationCommandAutocomplete` のみ扱う。ここに `MessageComponent` (type=3) を追加する。
+
+Command 型の拡張方針:
+
+```ts
+type Command = {
+  default: { name: string; description: string };
+  createResponse: (...) => Promise<APIInteractionResponse | null>;
+  createAutocompleteResponse?: (...) => ...;
+  // 追加
+  createComponentResponse?: (
+    interaction: APIMessageComponentInteraction,
+  ) => Promise<ComponentResult | null>;
+};
+
+type ComponentResult = {
+  response: APIInteractionResponse;  // UPDATE_MESSAGE など即時応答
+  followup?: () => Promise<void>;    // ctx.waitUntil で非同期実行
+};
+```
+
+- custom_id の先頭セグメント（コロン分割）を namespace として commands から該当 Command を探す（`pokeinfo` → pokeinfo コマンド）。
+- pokeinfo コマンド内の `createComponentResponse` は `action` で分岐（現状は `share` のみ）。
+- `followup` は `DiscordApi` に followup webhook 送信メソッドを追加して呼ぶ。
+
+### DiscordApi への追加
+
+`src/discord/api.ts` に以下を追加:
+
+```ts
+async postInteractionFollowup(
+  applicationId: string,
+  interactionToken: string,
+  body: RESTPostAPIWebhookWithTokenJSONBody,
+): Promise<void>
+```
+
+エンドポイント: `POST /webhooks/{application_id}/{interaction_token}`（Bot token 不要、interaction_token で認証）。
+
+### 環境変数
+
+新規追加なし。`DISCORD_APPLICATION_ID` は既に `wrangler.toml` に存在。
+
+### テスト
+
+- `src/commands/pokeinfo.test.ts`（新規）: `createResponse` が ephemeral flag + Button component を含む response を返すこと。検索失敗時はボタンなし ephemeral を返すこと。
+- `src/commands/pokeinfo.test.ts`: `createComponentResponse` が UPDATE_MESSAGE + followup 関数を返すこと。custom_id のパースが正しいこと。
+- ルーティング層のテストはカバー既存範囲に準じて追加。
+
+## 代替案
+
+### A. 状態を KV に保存
+
+custom_id に短い ID だけ入れて、embed 本体を KV に保存する方式。
+
+- 却下理由: 単純な再検索で済む処理にストレージ I/O を増やす必然性がない。TTL 管理も必要で複雑化。stateless で足りる。
+
+### B. UPDATE_MESSAGE を使わず ChannelMessageWithSource で公開投稿
+
+ボタン押下時に `ChannelMessageWithSource`（flags なし）を返して公開メッセージにし、ephemeral 側は放置する方式。
+
+- 却下理由: ephemeral にボタンが残り続け、再押下で多重投稿が起きる。UX が悪い。
+
+### C. Command 型拡張ではなく独立した ComponentHandler registry
+
+`src/components/` ディレクトリに custom_id namespace ごとの handler を並べる方式。
+
+- 却下の理由というより選択理由: pokeinfo の slash command と share ボタンは同一ドメインの機能。コマンド単位にまとまっている方が凝集度が高い。将来 namespace が増えて 3 つ以上のコマンドが components を持つようになったら再検討。
+
+## リスク・未解決事項
+
+- **followup 失敗時のハンドリング**: webhook 投稿が失敗した場合、ephemeral 側は既に「共有しました」に更新済みで、ユーザーには共有されたように見えるが実際には投稿されない状態になりうる。対策: followup を先に実行し、成功後に UPDATE_MESSAGE を送る——は Discord の 3 秒応答制限に抵触するため不可。採用案: followup 失敗時は Sentry に記録、ephemeral を再編集（PATCH original）して「共有に失敗しました」に差し戻す。実装コスト低いので初版から入れる。
+- **Ephemeral メッセージの寿命**: Discord クライアント側の ephemeral は数分〜数十分で自動的にフェードするが、その間は API からは取得可能。UPDATE_MESSAGE 応答後すぐにボタンは消えるので、寿命による問題はない。
+- **Discord の interaction_token 寿命**: 15 分。ユーザーがそれを超えてボタンを押すと followup に失敗する。この場合 Discord 側で「このインタラクションは失敗しました」と表示されるので Bot 側で検知不要。
+
+## 実装計画
+
+1. `src/discord/api.ts` に `postInteractionFollowup` を追加。
+2. Command 型に `createComponentResponse` を追加し、`src/discord/interactions.ts` に MessageComponent 分岐を追加。
+3. `src/commands/pokeinfo.ts` の `createResponse` を ephemeral + Button に変更、`createComponentResponse` を実装。
+4. テスト追加。
+5. 動作確認（wrangler dev + Discord 開発サーバー）。
+
+コード変更はいずれも小さく、段階的にコミット可能。

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,9 +3,22 @@ import {
   APIApplicationCommandAutocompleteResponse,
   APIApplicationCommandInteraction,
   APIInteractionResponse,
+  APIMessageComponentInteraction,
 } from 'discord-api-types/v10';
+import DiscordApi from '../discord/api';
 import * as ping from './ping';
 import * as pokeinfo from './pokeinfo';
+
+export type ComponentFollowupContext = {
+  applicationId: string;
+  interactionToken: string;
+  discord: DiscordApi;
+};
+
+export type ComponentResult = {
+  response: APIInteractionResponse;
+  followup?: (ctx: ComponentFollowupContext) => Promise<void>;
+};
 
 type Command = {
   default: {
@@ -18,6 +31,9 @@ type Command = {
   createAutocompleteResponse?: (
     interaction: APIApplicationCommandAutocompleteInteraction,
   ) => Promise<APIApplicationCommandAutocompleteResponse | null>;
+  createComponentResponse?: (
+    interaction: APIMessageComponentInteraction,
+  ) => Promise<ComponentResult | null>;
 };
 
 export const commands: Command[] = [ping, pokeinfo];

--- a/src/commands/pokeinfo.test.ts
+++ b/src/commands/pokeinfo.test.ts
@@ -1,0 +1,182 @@
+import {
+  APIApplicationCommandInteraction,
+  APIMessageComponentInteraction,
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+  ComponentType,
+  InteractionResponseType,
+  InteractionType,
+  MessageFlags,
+} from 'discord-api-types/v10';
+import { describe, expect, test, vi } from 'vitest';
+import { createComponentResponse, createResponse } from './pokeinfo';
+
+function buildSlashInteraction(name: string): APIApplicationCommandInteraction {
+  return {
+    id: '1',
+    application_id: 'app',
+    token: 'tok',
+    version: 1,
+    type: InteractionType.ApplicationCommand,
+    data: {
+      id: 'cmd',
+      name: 'pokeinfo',
+      type: ApplicationCommandType.ChatInput,
+      options: [
+        {
+          name: 'name',
+          type: ApplicationCommandOptionType.String,
+          value: name,
+        },
+      ],
+    },
+    app_permissions: '0',
+    authorizing_integration_owners: {},
+    entitlements: [],
+    locale: 'ja',
+    channel: { id: 'c', type: 0 },
+    channel_id: 'c',
+    attachment_size_limit: 8388608,
+  } as unknown as APIApplicationCommandInteraction;
+}
+
+function buildComponentInteraction(
+  customId: string,
+): APIMessageComponentInteraction {
+  return {
+    id: '2',
+    application_id: 'app',
+    token: 'tok',
+    version: 1,
+    type: InteractionType.MessageComponent,
+    data: {
+      custom_id: customId,
+      component_type: ComponentType.Button,
+    },
+    message: {},
+    app_permissions: '0',
+    authorizing_integration_owners: {},
+    entitlements: [],
+    locale: 'ja',
+    channel: { id: 'c', type: 0 },
+    channel_id: 'c',
+    attachment_size_limit: 8388608,
+  } as unknown as APIMessageComponentInteraction;
+}
+
+describe('createResponse', () => {
+  test('known pokemon returns ephemeral embed with share button', async () => {
+    const res = await createResponse(buildSlashInteraction('ピカチュウ'));
+    expect(res).not.toBeNull();
+    expect(res!.type).toBe(InteractionResponseType.ChannelMessageWithSource);
+    const data = (res as { data: Record<string, unknown> }).data;
+    expect(data.flags).toBe(MessageFlags.Ephemeral);
+    expect(Array.isArray(data.embeds)).toBe(true);
+    const components = data.components as Array<{
+      components: Array<{ custom_id: string; label: string }>;
+    }>;
+    expect(components).toHaveLength(1);
+    const button = components[0]!.components[0]!;
+    expect(button.custom_id).toBe('pokeinfo:share:ピカチュウ');
+    expect(button.label).toBe('チャンネルにシェア');
+  });
+
+  test('unknown pokemon returns ephemeral text without button', async () => {
+    const res = await createResponse(buildSlashInteraction('__nope__'));
+    expect(res).not.toBeNull();
+    const data = (res as { data: Record<string, unknown> }).data;
+    expect(data.flags).toBe(MessageFlags.Ephemeral);
+    expect(data.components).toBeUndefined();
+    expect(data.content).toContain('見つからなかった');
+  });
+});
+
+describe('createComponentResponse', () => {
+  test('share button updates ephemeral and posts public followup', async () => {
+    const res = await createComponentResponse(
+      buildComponentInteraction('pokeinfo:share:ピカチュウ'),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.response.type).toBe(InteractionResponseType.UpdateMessage);
+    const data = (res!.response as { data: Record<string, unknown> }).data;
+    expect(data.components).toEqual([]);
+    expect(data.embeds).toEqual([]);
+    expect(data.content).toBeDefined();
+
+    expect(res!.followup).toBeDefined();
+    const postInteractionFollowup = vi.fn<
+      (
+        appId: string,
+        token: string,
+        body: { embeds: unknown[] },
+      ) => Promise<Response>
+    >(async () => new Response('{}'));
+    const patchOriginalInteractionResponse = vi.fn<
+      (appId: string, token: string, body: unknown) => Promise<Response>
+    >(async () => new Response('{}'));
+    await res!.followup!({
+      applicationId: 'app',
+      interactionToken: 'tok',
+      discord: {
+        postInteractionFollowup,
+        patchOriginalInteractionResponse,
+      } as never,
+    });
+    expect(postInteractionFollowup).toHaveBeenCalledTimes(1);
+    const [appId, token, body] = postInteractionFollowup.mock.calls[0]!;
+    expect(appId).toBe('app');
+    expect(token).toBe('tok');
+    expect(body.embeds).toHaveLength(1);
+    expect(patchOriginalInteractionResponse).not.toHaveBeenCalled();
+  });
+
+  test('share action with unknown pokemon returns UpdateMessage with not-found', async () => {
+    const res = await createComponentResponse(
+      buildComponentInteraction('pokeinfo:share:__nope__'),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.response.type).toBe(InteractionResponseType.UpdateMessage);
+    expect(res!.followup).toBeUndefined();
+  });
+
+  test('followup failure rolls back ephemeral via PATCH original', async () => {
+    const res = await createComponentResponse(
+      buildComponentInteraction('pokeinfo:share:ピカチュウ'),
+    );
+    const postInteractionFollowup = vi.fn<
+      (appId: string, token: string, body: unknown) => Promise<Response>
+    >(async () => {
+      throw new Error('boom');
+    });
+    const patchOriginalInteractionResponse = vi.fn<
+      (appId: string, token: string, body: unknown) => Promise<Response>
+    >(async () => new Response('{}'));
+    await expect(
+      res!.followup!({
+        applicationId: 'app',
+        interactionToken: 'tok',
+        discord: {
+          postInteractionFollowup,
+          patchOriginalInteractionResponse,
+        } as never,
+      }),
+    ).rejects.toThrow('boom');
+    expect(patchOriginalInteractionResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test('unknown action returns null', async () => {
+    const res = await createComponentResponse(
+      buildComponentInteraction('pokeinfo:unknown:foo'),
+    );
+    expect(res).toBeNull();
+  });
+
+  test('name containing colon is preserved via rest join', async () => {
+    const res = await createComponentResponse(
+      buildComponentInteraction('pokeinfo:share:ア:イ'),
+    );
+    expect(res).not.toBeNull();
+    const data = (res!.response as { data: Record<string, unknown> }).data;
+    expect(data.content).toContain('"ア:イ"');
+  });
+});

--- a/src/commands/pokeinfo.ts
+++ b/src/commands/pokeinfo.ts
@@ -1,14 +1,21 @@
 import {
+  APIActionRowComponent,
   APIApplicationCommandAutocompleteInteraction,
   APIApplicationCommandAutocompleteResponse,
   APIApplicationCommandInteraction,
   APIApplicationCommandInteractionDataStringOption,
   APIInteractionResponse,
+  APIComponentInMessageActionRow,
+  APIMessageComponentInteraction,
   ApplicationCommandOptionType,
   ApplicationCommandType,
+  ButtonStyle,
+  ComponentType,
   InteractionResponseType,
+  MessageFlags,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
+import { ComponentResult } from '.';
 import { buildPokemonViewModel } from '../pokeinfo/view-model';
 import { formatPokemonEmbed } from '../pokeinfo/embed';
 import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
@@ -27,13 +34,14 @@ export default {
   ],
 } satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
 
+const SHARE_ACTION = 'share';
+
 export async function createResponse(
   interaction: APIApplicationCommandInteraction,
 ): Promise<APIInteractionResponse | null> {
   if (interaction.data.type !== ApplicationCommandType.ChatInput) {
     return null;
   }
-  // Get name option
   const options = interaction.data.options ?? [];
   const nameOption = options.find((option) => option.name === 'name');
   if (nameOption?.type !== ApplicationCommandOptionType.String) {
@@ -42,24 +50,82 @@ export async function createResponse(
   const name = nameOption.value;
   console.log(`[pokeinfo] name: ${name}`);
 
-  // Search pokemon by name
   const data = await searchPokemonByName(name);
-  if (data) {
-    console.log(`[pokeinfo] found pokemon: ${data.yakkun?.url ?? name}`);
-    const viewModel = buildPokemonViewModel(name, data);
-    const embed = formatPokemonEmbed(viewModel);
+  if (!data) {
     return {
       type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        embeds: [embed],
+        content: `"${name}" の情報は見つからなかったロトね...`,
+        flags: MessageFlags.Ephemeral,
       },
     };
-  } else {
+  }
+  console.log(`[pokeinfo] found pokemon: ${data.yakkun?.url ?? name}`);
+  const viewModel = buildPokemonViewModel(name, data);
+  const embed = formatPokemonEmbed(viewModel);
+  return {
+    type: InteractionResponseType.ChannelMessageWithSource,
+    data: {
+      embeds: [embed],
+      components: [buildShareActionRow(name)],
+      flags: MessageFlags.Ephemeral,
+    },
+  };
+}
+
+export async function createComponentResponse(
+  interaction: APIMessageComponentInteraction,
+): Promise<ComponentResult | null> {
+  const customId = interaction.data.custom_id;
+  const [, action, ...rest] = customId.split(':');
+  if (action !== SHARE_ACTION) {
+    return null;
+  }
+  const name = rest.join(':');
+  if (!name) {
+    return null;
+  }
+  const data = await searchPokemonByName(name);
+  if (!data) {
     return {
-      type: InteractionResponseType.ChannelMessageWithSource,
-      data: { content: `"${name}" の情報は見つからなかったロトね...` },
+      response: {
+        type: InteractionResponseType.UpdateMessage,
+        data: {
+          content: `"${name}" の情報は見つからなかったロトね...`,
+          embeds: [],
+          components: [],
+        },
+      },
     };
   }
+  const viewModel = buildPokemonViewModel(name, data);
+  const embed = formatPokemonEmbed(viewModel);
+  return {
+    response: {
+      type: InteractionResponseType.UpdateMessage,
+      data: {
+        content: 'チャンネルにシェアしたロト！',
+        embeds: [],
+        components: [],
+      },
+    },
+    followup: async ({ applicationId, interactionToken, discord }) => {
+      try {
+        await discord.postInteractionFollowup(applicationId, interactionToken, {
+          embeds: [embed],
+        });
+      } catch (e) {
+        await discord
+          .patchOriginalInteractionResponse(applicationId, interactionToken, {
+            content: `シェアに失敗したロト... (${name})`,
+            embeds: [embed],
+            components: [buildShareActionRow(name)],
+          })
+          .catch((e2) => console.error('Rollback failed:', e2));
+        throw e;
+      }
+    },
+  };
 }
 
 export async function createAutocompleteResponse(
@@ -81,5 +147,21 @@ export async function createAutocompleteResponse(
     data: {
       choices: choices.map((choice) => ({ name: choice, value: choice })),
     },
+  };
+}
+
+function buildShareActionRow(
+  name: string,
+): APIActionRowComponent<APIComponentInMessageActionRow> {
+  return {
+    type: ComponentType.ActionRow,
+    components: [
+      {
+        type: ComponentType.Button,
+        style: ButtonStyle.Primary,
+        label: 'チャンネルにシェア',
+        custom_id: `pokeinfo:${SHARE_ACTION}:${name}`,
+      },
+    ],
   };
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import { Sentry } from './observability/types';
 export type Env = {
   SENTRY_DSN: string;
   NEWS_KV: KVNamespace;
+  DISCORD_APPLICATION_ID: string;
   DISCORD_TOKEN: string;
   DISCORD_PUBLIC_KEY: string;
   NEWS_NOTIFICATION_CHANNEL_ID: string;

--- a/src/discord/api.ts
+++ b/src/discord/api.ts
@@ -1,5 +1,6 @@
 import {
   RESTPostAPIChannelMessageJSONBody,
+  RESTPostAPIWebhookWithTokenJSONBody,
   RESTPutAPIApplicationGuildCommandsJSONBody,
 } from 'discord-api-types/v10';
 
@@ -29,6 +30,33 @@ export default class DiscordApi {
   }
 
   /**
+   * Create Followup Message for an Interaction (channel-visible by default).
+   * interaction_token authenticates the request; bot token is not used.
+   * @see https://discord.com/developers/docs/interactions/receiving-and-responding#create-followup-message
+   */
+  async postInteractionFollowup(
+    applicationId: string,
+    interactionToken: string,
+    body: RESTPostAPIWebhookWithTokenJSONBody,
+  ): Promise<Response> {
+    const url = `${baseUrl}/webhooks/${applicationId}/${interactionToken}`;
+    return await this.#requestUnauthenticated(url, 'POST', body);
+  }
+
+  /**
+   * Edit the Original Interaction Response (used to roll back on followup failure).
+   * @see https://discord.com/developers/docs/interactions/receiving-and-responding#edit-original-interaction-response
+   */
+  async patchOriginalInteractionResponse(
+    applicationId: string,
+    interactionToken: string,
+    body: RESTPostAPIWebhookWithTokenJSONBody,
+  ): Promise<Response> {
+    const url = `${baseUrl}/webhooks/${applicationId}/${interactionToken}/messages/@original`;
+    return await this.#requestUnauthenticated(url, 'PATCH', body);
+  }
+
+  /**
    * Bulk Overwrite Guild Application Commands
    * @see https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands
    */
@@ -47,22 +75,38 @@ export default class DiscordApi {
     body: unknown,
     headers = {},
   ): Promise<Response> {
-    const response = await fetch(url, {
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bot ${this.#token}`,
-        ...headers,
-      },
-      body: JSON.stringify(body),
+    return await sendJson(url, method, body, {
+      Authorization: `Bot ${this.#token}`,
+      ...headers,
     });
-    if (!response.ok) {
-      const text = await response.text();
-      console.error(text);
-      throw new Error(
-        `Failed to request ${url}: ${response.status} ${response.statusText}`,
-      );
-    }
-    return response;
   }
+
+  async #requestUnauthenticated(
+    url: string,
+    method: string,
+    body: unknown,
+  ): Promise<Response> {
+    return await sendJson(url, method, body, {});
+  }
+}
+
+async function sendJson(
+  url: string,
+  method: string,
+  body: unknown,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const response = await fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    console.error(text);
+    throw new Error(
+      `Failed to request ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+  return response;
 }

--- a/src/discord/interactions.ts
+++ b/src/discord/interactions.ts
@@ -3,15 +3,21 @@ import {
   APIApplicationCommandInteraction,
   APIInteraction,
   APIInteractionResponse,
+  APIMessageComponentInteraction,
   InteractionResponseType,
   InteractionType,
 } from 'discord-api-types/v10';
 import { verifyKey } from 'discord-interactions';
 import { MiddlewareHandler } from 'hono';
-import { getCommandByName } from '../commands';
+import { ComponentFollowupContext, getCommandByName } from '../commands';
 import { HonoAppContext } from '../context';
 
 export type Interaction = APIInteraction;
+
+export type InteractionResult = {
+  response: APIInteractionResponse | null;
+  followup?: (ctx: ComponentFollowupContext) => Promise<void>;
+};
 
 export const verifyKeyMiddleware =
   (): MiddlewareHandler<HonoAppContext> => async (c, next) => {
@@ -32,17 +38,24 @@ export const verifyKeyMiddleware =
 // https://discord.com/developers/docs/interactions/receiving-and-responding#interactions
 export async function handleInteractionRequest(
   interaction: Interaction,
-): Promise<APIInteractionResponse | null> {
+): Promise<InteractionResult> {
   console.log(
     `handleInteractionRequest: ${interaction.type} ${interaction.id}`,
   );
   switch (interaction.type) {
     case InteractionType.Ping:
-      return { type: InteractionResponseType.Pong };
+      return { response: { type: InteractionResponseType.Pong } };
     case InteractionType.ApplicationCommand:
-      return await handleApplicationCommandInteraction(interaction);
+      return {
+        response: await handleApplicationCommandInteraction(interaction),
+      };
     case InteractionType.ApplicationCommandAutocomplete:
-      return await handleApplicationCommandAutocompleteInteraction(interaction);
+      return {
+        response:
+          await handleApplicationCommandAutocompleteInteraction(interaction),
+      };
+    case InteractionType.MessageComponent:
+      return await handleMessageComponentInteraction(interaction);
   }
   throw new Error('Unknown interaction');
 }
@@ -67,4 +80,20 @@ async function handleApplicationCommandAutocompleteInteraction(
     return await command.createAutocompleteResponse(interaction);
   }
   return null;
+}
+
+async function handleMessageComponentInteraction(
+  interaction: APIMessageComponentInteraction,
+): Promise<InteractionResult> {
+  const customId = interaction.data.custom_id;
+  const [namespace] = customId.split(':');
+  const command = namespace ? getCommandByName(namespace) : undefined;
+  if (command && command.createComponentResponse) {
+    const result = await command.createComponentResponse(interaction);
+    if (result) {
+      return result;
+    }
+  }
+  console.warn(`No handler for component custom_id: ${customId}`);
+  return { response: null };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,21 @@ app.get('/', (c) => c.text('Hello!'));
  */
 app.post('/api/interactions', verifyKeyMiddleware(), async (c) => {
   const interaction = await c.req.json<Interaction>();
-  const response = await handleInteractionRequest(interaction);
+  const { response, followup } = await handleInteractionRequest(interaction);
+  if (followup && 'token' in interaction) {
+    const discord = new DiscordApi(c.env.DISCORD_TOKEN);
+    const ctx: Parameters<typeof followup>[0] = {
+      applicationId: c.env.DISCORD_APPLICATION_ID,
+      interactionToken: interaction.token,
+      discord,
+    };
+    c.executionCtx.waitUntil(
+      followup(ctx).catch((e) => {
+        console.error('Followup failed:', e);
+        c.var.sentry?.captureException(e);
+      }),
+    );
+  }
   if (response) {
     return c.json(response);
   } else {


### PR DESCRIPTION
## Summary

- `/pokeinfo` を即時公開投稿から 2 段階フローに変更: まず実行者にしか見えない ephemeral embed + 「チャンネルにシェア」ボタンを返し、押下時に public メッセージとして投稿
- 意図しない検索結果は押さずに放置すればノイズゼロで終わる（検索失敗も ephemeral で完結）
- 汎用拡張として `Command` 型に `createComponentResponse` を追加、`MessageComponent` interaction を custom_id namespace prefix で dispatch

詳細は `docs/0001-pokeinfo-share-button.md` を参照。

## 技術要点

- `custom_id`: `pokeinfo:share:<日本語名>`（`data.generated.json` の primary key をそのまま使用、stateless）
- Followup: `ctx.waitUntil` で `POST /webhooks/{app_id}/{token}` を非同期発火
- ロールバック: followup 失敗時は `PATCH /webhooks/.../@original` で ephemeral にボタンを復元 + Sentry に記録
- `Env` 型に `DISCORD_APPLICATION_ID` を追加（wrangler.toml に既存）

## Test plan

- [x] typecheck / lint / format / test (41 tests) 全て pass
- [ ] wrangler dev で手動動作確認（次のステップ）
  - [ ] `/pokeinfo name:ピカチュウ` で ephemeral + ボタンが表示される
  - [ ] ボタン押下で public 投稿 + ephemeral がボタン消えた状態に更新される
  - [ ] `/pokeinfo name:__nope__` で ephemeral テキストのみ（ボタンなし）
  - [ ] 他ユーザーからは ephemeral が見えない

🤖 Generated with [Claude Code](https://claude.com/claude-code)