### PR TITLE
feat(speedcompare): add speed comparison command + Champions SP refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ pnpm register-commands    # Discordスラッシュコマンドを登録（環境
 
 3レイヤー構成:
 - `src/pokeinfo/index.ts`: データアクセス（Pokemon型、検索関数）
-- `src/pokeinfo/view-model.ts`: 何を表示するか（PokemonViewModel、StatActuals — baseStatsからLv.50実数値4値を計算）
+- `src/pokeinfo/view-model.ts`: 何を表示するか（PokemonViewModel、StatActuals — baseStatsからPokémon Champions仕様(Lv.50・個体値31・SP 0/32・性格0.9/1.0/1.1)で実数値4値を計算。従来の「努力値」概念は使わず、ステータス計算は常にSP(Status Point, 0〜32)で表現する）
 - `src/pokeinfo/embed.ts`: どう表示するか（Discord Embed構築 — fields、footer、タイプ色）
 
 テストもソース構造に対応して分割: `index.test.ts` / `view-model.test.ts` / `embed.test.ts`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,6 +8,7 @@ import {
 import DiscordApi from '../discord/api';
 import * as ping from './ping';
 import * as pokeinfo from './pokeinfo';
+import * as speedcompare from './speedcompare';
 
 export type ComponentFollowupContext = {
   applicationId: string;
@@ -36,7 +37,7 @@ type Command = {
   ) => Promise<ComponentResult | null>;
 };
 
-export const commands: Command[] = [ping, pokeinfo];
+export const commands: Command[] = [ping, pokeinfo, speedcompare];
 
 export function getCommandByName(name: string) {
   return commands.find((c) => c.default.name === name);

--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -1,0 +1,145 @@
+import {
+  APIApplicationCommandAutocompleteInteraction,
+  APIApplicationCommandAutocompleteResponse,
+  APIApplicationCommandInteraction,
+  APIInteractionResponse,
+  ApplicationCommandOptionType,
+  ApplicationCommandType,
+  InteractionResponseType,
+  MessageFlags,
+  RESTPostAPIChatInputApplicationCommandsJSONBody,
+} from 'discord-api-types/v10';
+import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
+import type { Nature } from '../speedcompare/compare';
+import { buildSpeedCompareViewModel } from '../speedcompare/view-model';
+import { formatSpeedCompareEmbed } from '../speedcompare/embed';
+
+const NATURE_UP = 'up';
+const NATURE_NEUTRAL = 'neutral';
+const NATURE_DOWN = 'down';
+
+export default {
+  name: 'speedcompare',
+  description: 'ベースポケモンAと仮想敵Bのすばやさ関係を分析します',
+  options: [
+    {
+      name: 'a',
+      description: 'ベースポケモンA（自分側）',
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: true,
+    },
+    {
+      name: 'a_sp',
+      description: 'Aの素早さSP (0〜32)',
+      type: ApplicationCommandOptionType.Integer,
+      required: true,
+      min_value: 0,
+      max_value: 32,
+    },
+    {
+      name: 'a_nature',
+      description: 'Aの性格補正',
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      choices: [
+        { name: '↑補正', value: NATURE_UP },
+        { name: '無補正', value: NATURE_NEUTRAL },
+        { name: '↓補正', value: NATURE_DOWN },
+      ],
+    },
+    {
+      name: 'b',
+      description: '仮想敵ポケモンB',
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: true,
+    },
+  ],
+} satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
+
+function parseNature(value: string): Nature {
+  if (value === NATURE_UP) return 1.1;
+  if (value === NATURE_DOWN) return 0.9;
+  return 1.0;
+}
+
+export async function createResponse(
+  interaction: APIApplicationCommandInteraction,
+): Promise<APIInteractionResponse | null> {
+  if (interaction.data.type !== ApplicationCommandType.ChatInput) {
+    return null;
+  }
+  const options = interaction.data.options ?? [];
+  const aOpt = options.find((o) => o.name === 'a');
+  const spOpt = options.find((o) => o.name === 'a_sp');
+  const natureOpt = options.find((o) => o.name === 'a_nature');
+  const bOpt = options.find((o) => o.name === 'b');
+  if (
+    aOpt?.type !== ApplicationCommandOptionType.String ||
+    spOpt?.type !== ApplicationCommandOptionType.Integer ||
+    natureOpt?.type !== ApplicationCommandOptionType.String ||
+    bOpt?.type !== ApplicationCommandOptionType.String
+  ) {
+    return null;
+  }
+
+  const aName = aOpt.value;
+  const aSp = spOpt.value;
+  const aNature = parseNature(natureOpt.value);
+  const bName = bOpt.value;
+  console.log(
+    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
+  );
+
+  const [aData, bData] = await Promise.all([
+    searchPokemonByName(aName),
+    searchPokemonByName(bName),
+  ]);
+  if (!aData || !bData) {
+    const missing = [!aData && `"${aName}"`, !bData && `"${bName}"`]
+      .filter(Boolean)
+      .join(' と ');
+    return {
+      type: InteractionResponseType.ChannelMessageWithSource,
+      data: {
+        content: `${missing} の情報は見つからなかったロトね...`,
+        flags: MessageFlags.Ephemeral,
+      },
+    };
+  }
+
+  const vm = buildSpeedCompareViewModel({
+    a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
+    b: { name: bName, pokemon: bData },
+  });
+  const embed = formatSpeedCompareEmbed(vm);
+  return {
+    type: InteractionResponseType.ChannelMessageWithSource,
+    data: {
+      embeds: [embed],
+      flags: MessageFlags.Ephemeral,
+    },
+  };
+}
+
+export async function createAutocompleteResponse(
+  interaction: APIApplicationCommandAutocompleteInteraction,
+): Promise<APIApplicationCommandAutocompleteResponse | null> {
+  const focused = interaction.data.options.find(
+    (o) => o.type === ApplicationCommandOptionType.String && o.focused,
+  );
+  if (!focused || focused.type !== ApplicationCommandOptionType.String) {
+    return null;
+  }
+  if (focused.name !== 'a' && focused.name !== 'b') {
+    return null;
+  }
+  const choices = await getAllPokemonNames({ prefix: focused.value });
+  return {
+    type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+    data: {
+      choices: choices.slice(0, 25).map((c) => ({ name: c, value: c })),
+    },
+  };
+}

--- a/src/pokeinfo/stats.test.ts
+++ b/src/pokeinfo/stats.test.ts
@@ -2,29 +2,29 @@ import { describe, expect, test } from 'vitest';
 import { calcActuals, calcHP, calcStat } from './stats';
 
 describe('calcHP', () => {
-  test('calculates HP at Lv.50 with 252 EV', () => {
-    // テツノツツミ H=56: floor((112+31+63)*50/100)+60 = 163
-    expect(calcHP(56, 252)).toBe(163);
+  test('calculates HP at Lv.50 with 32 SP', () => {
+    // テツノツツミ H=56: floor((112+31+64)*50/100)+60 = 163
+    expect(calcHP(56, 32)).toBe(163);
   });
 
-  test('calculates HP at Lv.50 with 0 EV', () => {
+  test('calculates HP at Lv.50 with 0 SP', () => {
     // テツノツツミ H=56: floor((112+31)*50/100)+60 = 131
     expect(calcHP(56, 0)).toBe(131);
   });
 });
 
 describe('calcStat', () => {
-  test('calculates stat with +nature and 252 EV', () => {
-    // テツノツツミ S=136: floor((floor((272+31+63)*50/100)+5)*1.1) = 206
-    expect(calcStat(136, 252, 1.1)).toBe(206);
+  test('calculates stat with +nature and 32 SP', () => {
+    // テツノツツミ S=136: floor((floor((272+31+64)*50/100)+5)*1.1) = 206
+    expect(calcStat(136, 32, 1.1)).toBe(206);
   });
 
-  test('calculates stat with neutral nature and 0 EV', () => {
+  test('calculates stat with neutral nature and 0 SP', () => {
     // テツノツツミ S=136: floor((floor((272+31)*50/100)+5)*1.0) = 156
     expect(calcStat(136, 0, 1.0)).toBe(156);
   });
 
-  test('calculates stat with -nature and 0 EV', () => {
+  test('calculates stat with -nature and 0 SP', () => {
     // テツノツツミ S=136: floor((floor((272+31)*50/100)+5)*0.9) = 140
     expect(calcStat(136, 0, 0.9)).toBe(140);
   });

--- a/src/pokeinfo/stats.ts
+++ b/src/pokeinfo/stats.ts
@@ -1,35 +1,35 @@
 /**
- * ポケモンのステータス実数値計算（Lv.50）
+ * Pokémon Champions のステータス実数値計算（Lv.50、個体値31固定）
+ *
+ * ステータスポイント (SP): 各ステータス 0〜32 の範囲で振れる
+ * (ゲーム内では合計66の制約があるが、本関数は単一ステータスのみを扱う)
  */
 
-/** HP実数値: (2*base + IV + EV/4) * Lv/100 + Lv + 10 */
-export function calcHP(base: number, ev: number): number {
-  return (
-    Math.floor(((2 * base + 31 + Math.floor(ev / 4)) * 50) / 100) + 50 + 10
-  );
+/** HP実数値: (2*base + 31 + SP*2) * 50/100 + 60 */
+export function calcHP(base: number, sp: number): number {
+  return Math.floor(((2 * base + 31 + sp * 2) * 50) / 100) + 60;
 }
 
-/** HP以外の実数値: ((2*base + IV + EV/4) * Lv/100 + 5) * nature */
-export function calcStat(base: number, ev: number, nature: number): number {
+/** HP以外の実数値: floor((floor((2*base + 31 + SP*2) * 50/100) + 5) * nature) */
+export function calcStat(base: number, sp: number, nature: number): number {
   return Math.floor(
-    (Math.floor(((2 * base + 31 + Math.floor(ev / 4)) * 50) / 100) + 5) *
-      nature,
+    (Math.floor(((2 * base + 31 + sp * 2) * 50) / 100) + 5) * nature,
   );
 }
 
-/** 4段階の実数値を計算: [速(+性格252EV), 準(無性格252EV), 無(無性格0EV), 遅(-性格0EV)] */
+/** 4段階の実数値を計算: [速(+性格32SP), 準(無性格32SP), 無(無性格0SP), 遅(-性格0SP)] */
 export function calcActuals(
   key: string,
   base: number,
 ): [number, number, number, number] {
   if (key === 'H') {
-    const max = calcHP(base, 252);
+    const max = calcHP(base, 32);
     const min = calcHP(base, 0);
     return [max, max, min, min];
   }
   return [
-    calcStat(base, 252, 1.1),
-    calcStat(base, 252, 1.0),
+    calcStat(base, 32, 1.1),
+    calcStat(base, 32, 1.0),
     calcStat(base, 0, 1.0),
     calcStat(base, 0, 0.9),
   ];

--- a/src/pokeinfo/view-model.ts
+++ b/src/pokeinfo/view-model.ts
@@ -13,13 +13,13 @@ const STAT_KEYS: (keyof Pokemon['baseStats'])[] = [
 export type StatActuals = {
   key: string;
   base: number;
-  /** 性格↑ 努力値252 (HPは null) */
+  /** 性格↑ SP32 (HPは null) */
   maxPlus: number | null;
-  /** 性格無 努力値252 */
+  /** 性格無 SP32 */
   max: number;
-  /** 性格無 努力値0 */
+  /** 性格無 SP0 */
   min: number;
-  /** 性格↓ 努力値0 (HPは null) */
+  /** 性格↓ SP0 (HPは null) */
   minMinus: number | null;
 };
 

--- a/src/speedcompare/compare.test.ts
+++ b/src/speedcompare/compare.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import { findMinimalReversal } from './compare';
+
+describe('findMinimalReversal', () => {
+  // Aの有効速を固定、Bの素早さ種族値とBのランクに対し、
+  // Bが逆転する (B > A となる) 最小調整 (SP, nature) を探す。
+
+  test('returns always_a when B cannot outspeed A even at max', () => {
+    // A = 300 (非常に高速), B base = 50 (遅い), rank 0
+    // B最速でも calcStat(50, 32, 1.1) = 99 < 300
+    expect(findMinimalReversal(300, 50, 0)).toEqual({ kind: 'always_a' });
+  });
+
+  test('returns always_b when B outspeeds A even at min', () => {
+    // A = 50, B base = 200, rank 0
+    // B最遅 calcStat(200, 0, 0.9) = 184 > 50
+    expect(findMinimalReversal(50, 200, 0)).toEqual({ kind: 'always_b' });
+  });
+
+  test('finds minimum SP that reverses the matchup', () => {
+    // A = 156 (無振り 136族), B = 136族, rank 0
+    // SP=0 ↓: 140, SP=0 無: 156, SP=0 ↑: 171
+    // B > A (=156) になる最初: SP=0 ↑ (171 > 156)
+    const result = findMinimalReversal(156, 136, 0);
+    expect(result).toEqual({ kind: 'threshold', sp: 0, nature: 1.1 });
+  });
+
+  test('finds minimum SP with rank boost on B', () => {
+    // A = 250, B base = 136, rank +1
+    // B最遅 rank+1: floor(140 × 1.5) = 210 ≤ 250
+    // B SP=0 無: floor(156 × 1.5) = 234 ≤ 250
+    // B SP=0 ↑: floor(171 × 1.5) = 256 > 250 → 最小境界
+    expect(findMinimalReversal(250, 136, 1)).toEqual({
+      kind: 'threshold',
+      sp: 0,
+      nature: 1.1,
+    });
+  });
+
+  test('threshold scans SP ascending then nature ascending', () => {
+    // A = 188 (テツノツツミ 準速), B = 136, rank 0
+    // SP=15 ↑: floor(171*1.1) より計算 → 188 で同速
+    // SP=16 ↑: 189 > 188 → 最小境界
+    const result = findMinimalReversal(188, 136, 0);
+    expect(result).toEqual({ kind: 'threshold', sp: 16, nature: 1.1 });
+  });
+});

--- a/src/speedcompare/compare.ts
+++ b/src/speedcompare/compare.ts
@@ -1,0 +1,40 @@
+import { effectiveSpeed } from './speed';
+
+export type Nature = 0.9 | 1.0 | 1.1;
+
+export type ReversalResult =
+  | { kind: 'always_a' }
+  | { kind: 'always_b' }
+  | { kind: 'threshold'; sp: number; nature: Nature };
+
+export const NATURES: readonly Nature[] = [0.9, 1.0, 1.1] as const;
+export const MAX_SP = 32;
+
+/**
+ * B側のすべての調整 (SP 0〜32 × 性格 ↓/無/↑) のうち、
+ * 固定された A の有効速を上回る最小の調整を返す。
+ * 最小の定義: (SP 昇順, 性格 ↓→無→↑ 昇順)。
+ */
+export function findMinimalReversal(
+  aSpeed: number,
+  bBase: number,
+  bRank: number,
+): ReversalResult {
+  // 上限: B最速調整でもAに届かない → 常にA勝ち
+  if (effectiveSpeed(bBase, MAX_SP, 1.1, bRank) <= aSpeed) {
+    return { kind: 'always_a' };
+  }
+  // 下限: B最遅調整でもAを上回る → 常にB勝ち
+  if (effectiveSpeed(bBase, 0, 0.9, bRank) > aSpeed) {
+    return { kind: 'always_b' };
+  }
+  for (let sp = 0; sp <= MAX_SP; sp++) {
+    for (const nature of NATURES) {
+      if (effectiveSpeed(bBase, sp, nature, bRank) > aSpeed) {
+        return { kind: 'threshold', sp, nature };
+      }
+    }
+  }
+  // ここに到達する場合は論理的にありえない（上下限チェックで網羅済み）
+  return { kind: 'always_a' };
+}

--- a/src/speedcompare/embed.test.ts
+++ b/src/speedcompare/embed.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import { formatSpeedCompareEmbed } from './embed';
+import { buildSpeedCompareViewModel } from './view-model';
+import type { Pokemon } from '../pokeinfo';
+
+const fake = (baseS: number, overrides: Partial<Pokemon> = {}): Pokemon => ({
+  index: 0,
+  types: ['ノーマル'],
+  abilities: ['テスト'],
+  baseStats: { H: 100, A: 100, B: 100, C: 100, D: 100, S: baseS },
+  source: { game: 'test', pokedex: 'test' },
+  ...overrides,
+});
+
+describe('formatSpeedCompareEmbed', () => {
+  test('テツノツツミ(最速) vs テツノツツミ', () => {
+    const vm = buildSpeedCompareViewModel({
+      a: { name: 'テツノツツミ', pokemon: fake(136), sp: 32, nature: 1.1 },
+      b: { name: 'テツノツツミ', pokemon: fake(136) },
+    });
+    expect(formatSpeedCompareEmbed(vm)).toMatchInlineSnapshot(`
+      {
+        "color": 5793266,
+        "fields": [
+          {
+            "inline": false,
+            "name": "A: テツノツツミ",
+            "value": "SP32 ↑補正
+      S種族値 136 → 実数値 **206**",
+          },
+          {
+            "inline": false,
+            "name": "B: テツノツツミ",
+            "value": "S種族値 136 → 実数値 **206** / 188 / 156 / **140**",
+          },
+          {
+            "inline": false,
+            "name": "テツノツツミのランク別 逆転条件",
+            "value": "🔵 **-6〜±0** テツノツツミ > テツノツツミ
+      🔴 **+1〜+6** テツノツツミ < テツノツツミ",
+          },
+        ],
+        "footer": {
+          "text": "補正換算: スカーフ=+1 / おいかぜ=+2 / まひ=-2",
+        },
+        "title": "すばやさ比較ロト！",
+      }
+    `);
+  });
+
+  test('無振り vs 高速ポケモン', () => {
+    const vm = buildSpeedCompareViewModel({
+      a: { name: 'A', pokemon: fake(100), sp: 0, nature: 1.0 },
+      b: { name: 'B', pokemon: fake(150) },
+    });
+    const embed = formatSpeedCompareEmbed(vm);
+    // 基本フィールドが揃っていること
+    const fieldNames = embed.fields?.map((f) => f.name) ?? [];
+    expect(fieldNames).toContain('A: A');
+    expect(fieldNames).toContain('B: B');
+    expect(fieldNames).toContain('Bのランク別 逆転条件');
+  });
+});

--- a/src/speedcompare/embed.ts
+++ b/src/speedcompare/embed.ts
@@ -1,0 +1,108 @@
+import type { APIEmbed, APIEmbedField } from 'discord-api-types/v10';
+import type { Nature, ReversalResult } from './compare';
+import type { RankReversal, SpeedCompareViewModel } from './view-model';
+
+function formatNatureShort(nature: Nature): string {
+  if (nature === 1.1) return '↑';
+  if (nature === 0.9) return '↓';
+  return '';
+}
+
+function formatRank(rank: number): string {
+  if (rank === 0) return '±0';
+  if (rank > 0) return `+${rank}`;
+  return `${rank}`;
+}
+
+function formatResult(
+  result: ReversalResult,
+  aName: string,
+  bName: string,
+): string {
+  if (result.kind === 'always_a') return `${aName} > ${bName}`;
+  if (result.kind === 'always_b') return `${aName} < ${bName}`;
+  const nat = formatNatureShort(result.nature);
+  return `${bName} SP${result.sp}${nat}以上 → ${aName} < ${bName}`;
+}
+
+function resultsEqual(a: ReversalResult, b: ReversalResult): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'threshold' && b.kind === 'threshold') {
+    return a.sp === b.sp && a.nature === b.nature;
+  }
+  return true;
+}
+
+function formatRankRange(from: number, to: number): string {
+  if (from === to) return formatRank(from);
+  return `${formatRank(from)}〜${formatRank(to)}`;
+}
+
+function resultIcon(result: ReversalResult): string {
+  if (result.kind === 'always_a') return '🔵';
+  if (result.kind === 'always_b') return '🔴';
+  return '🟡';
+}
+
+/**
+ * 連続する同一結果をまとめて「アイコン + ランク + 結果」の3セクション構造にする。
+ * Aが勝つ範囲 / 逆転境界 / Bが勝つ範囲 を視覚的に分離。
+ */
+function formatReversals(
+  reversals: RankReversal[],
+  aName: string,
+  bName: string,
+): string {
+  type Group = { from: number; to: number; result: ReversalResult };
+  const groups: Group[] = [];
+  for (const r of reversals) {
+    const last = groups[groups.length - 1];
+    if (last && resultsEqual(last.result, r.result)) {
+      last.to = r.rank;
+    } else {
+      groups.push({ from: r.rank, to: r.rank, result: r.result });
+    }
+  }
+  return groups
+    .map((g) => {
+      const icon = resultIcon(g.result);
+      const range = formatRankRange(g.from, g.to);
+      const text = formatResult(g.result, aName, bName);
+      return `${icon} **${range}** ${text}`;
+    })
+    .join('\n');
+}
+
+function formatBReference(speeds: [number, number, number, number]): string {
+  const [max, sub, neutral, min] = speeds;
+  return `**${max}** / ${sub} / ${neutral} / **${min}**`;
+}
+
+export function formatSpeedCompareEmbed(vm: SpeedCompareViewModel): APIEmbed {
+  const fields: APIEmbedField[] = [
+    {
+      name: `A: ${vm.aName}`,
+      value: `${vm.aConfig}\nS種族値 ${vm.aBase} → 実数値 **${vm.aSpeed}**`,
+      inline: false,
+    },
+    {
+      name: `B: ${vm.bName}`,
+      value: `S種族値 ${vm.bBase} → 実数値 ${formatBReference(vm.bReferenceSpeeds)}`,
+      inline: false,
+    },
+    {
+      name: `${vm.bName}のランク別 逆転条件`,
+      value: formatReversals(vm.reversals, vm.aName, vm.bName),
+      inline: false,
+    },
+  ];
+
+  return {
+    title: 'すばやさ比較ロト！',
+    color: 0x5865f2,
+    fields,
+    footer: {
+      text: '補正換算: スカーフ=+1 / おいかぜ=+2 / まひ=-2',
+    },
+  };
+}

--- a/src/speedcompare/speed.test.ts
+++ b/src/speedcompare/speed.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { effectiveSpeed, rankMult } from './speed';
+
+describe('rankMult', () => {
+  test('rank 0 returns 1', () => {
+    expect(rankMult(0)).toBe(1);
+  });
+
+  test('positive ranks return (2 + rank) / 2', () => {
+    expect(rankMult(1)).toBe(1.5);
+    expect(rankMult(2)).toBe(2);
+    expect(rankMult(6)).toBe(4);
+  });
+
+  test('negative ranks return 2 / (2 - rank)', () => {
+    expect(rankMult(-1)).toBe(2 / 3);
+    expect(rankMult(-2)).toBe(0.5);
+    expect(rankMult(-6)).toBe(0.25);
+  });
+});
+
+describe('effectiveSpeed', () => {
+  // テツノツツミ S=136, 最速: calcStat(136, 32, 1.1) = 206
+  test('returns raw actual stat at rank 0', () => {
+    expect(effectiveSpeed(136, 32, 1.1, 0)).toBe(206);
+  });
+
+  test('floors after rank multiplier', () => {
+    // 206 × 1.5 = 309
+    expect(effectiveSpeed(136, 32, 1.1, 1)).toBe(309);
+    // 206 × 2 = 412 (tailwind equivalent)
+    expect(effectiveSpeed(136, 32, 1.1, 2)).toBe(412);
+    // 206 × 0.5 = 103 (paralysis equivalent)
+    expect(effectiveSpeed(136, 32, 1.1, -2)).toBe(103);
+  });
+
+  test('floors decimals from negative ranks', () => {
+    // 156 × 2/3 = 104.0 -> 104
+    expect(effectiveSpeed(136, 0, 1.0, -1)).toBe(104);
+  });
+});

--- a/src/speedcompare/speed.ts
+++ b/src/speedcompare/speed.ts
@@ -1,0 +1,26 @@
+import { calcStat } from '../pokeinfo/stats';
+
+/**
+ * 能力ランク補正倍率。
+ * 正: (2 + rank) / 2、負: 2 / (2 - rank)。
+ * ゲーム内の他の1.5/2/0.5倍補正との等価関係:
+ *   こだわりスカーフ = +1、おいかぜ = +2、まひ = -2。
+ */
+export function rankMult(rank: number): number {
+  if (rank >= 0) return (2 + rank) / 2;
+  return 2 / (2 - rank);
+}
+
+/**
+ * 有効素早さ = floor(実数値 × rankMult)。
+ * 中間の丸めは全て切り捨てで統一する。
+ */
+export function effectiveSpeed(
+  base: number,
+  sp: number,
+  nature: number,
+  rank: number,
+): number {
+  const actual = calcStat(base, sp, nature);
+  return Math.floor(actual * rankMult(rank));
+}

--- a/src/speedcompare/view-model.test.ts
+++ b/src/speedcompare/view-model.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+import { buildSpeedCompareViewModel } from './view-model';
+import type { Pokemon } from '../pokeinfo';
+
+const fake = (
+  name: string,
+  baseS: number,
+  overrides: Partial<Pokemon> = {},
+): { name: string; pokemon: Pokemon } => ({
+  name,
+  pokemon: {
+    index: 0,
+    types: ['ノーマル'],
+    abilities: ['テスト'],
+    baseStats: { H: 100, A: 100, B: 100, C: 100, D: 100, S: baseS },
+    source: { game: 'test', pokedex: 'test' },
+    ...overrides,
+  },
+});
+
+describe('buildSpeedCompareViewModel', () => {
+  test('A最速 vs B同族: B はrank 0で SP 0↑ 以上で逆転する', () => {
+    const a = fake('テツノツツミ', 136);
+    const b = fake('テツノツツミ', 136);
+    const vm = buildSpeedCompareViewModel({
+      a: { ...a, sp: 32, nature: 1.1 },
+      b,
+    });
+    expect(vm.aName).toBe('テツノツツミ');
+    expect(vm.aConfig).toBe('SP32 ↑補正');
+    expect(vm.aSpeed).toBe(206);
+    // Bランク0: B最速(AP32↑)=206 → 同速 → always_a (>の判定なので等速はA勝ち扱い)
+    // Bランク+1: B最遅(AP0↓)= floor(140*1.5)=210 > 206 → always_b
+    const rank0 = vm.reversals.find((r) => r.rank === 0);
+    expect(rank0?.result).toEqual({ kind: 'always_a' });
+    const rankPlus1 = vm.reversals.find((r) => r.rank === 1);
+    expect(rankPlus1?.result).toEqual({ kind: 'always_b' });
+  });
+
+  test('13ランク分を -6 〜 +6 で返す', () => {
+    const a = fake('A', 100);
+    const b = fake('B', 100);
+    const vm = buildSpeedCompareViewModel({
+      a: { ...a, sp: 0, nature: 1.0 },
+      b,
+    });
+    expect(vm.reversals.map((r) => r.rank)).toEqual([
+      -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6,
+    ]);
+  });
+});

--- a/src/speedcompare/view-model.test.ts
+++ b/src/speedcompare/view-model.test.ts
@@ -29,8 +29,8 @@ describe('buildSpeedCompareViewModel', () => {
     expect(vm.aName).toBe('テツノツツミ');
     expect(vm.aConfig).toBe('SP32 ↑補正');
     expect(vm.aSpeed).toBe(206);
-    // Bランク0: B最速(AP32↑)=206 → 同速 → always_a (>の判定なので等速はA勝ち扱い)
-    // Bランク+1: B最遅(AP0↓)= floor(140*1.5)=210 > 206 → always_b
+    // Bランク0: B最速(SP32↑)=206 → 同速 → always_a (>の判定なので等速はA勝ち扱い)
+    // Bランク+1: B最遅(SP0↓)= floor(140*1.5)=210 > 206 → always_b
     const rank0 = vm.reversals.find((r) => r.rank === 0);
     expect(rank0?.result).toEqual({ kind: 'always_a' });
     const rankPlus1 = vm.reversals.find((r) => r.rank === 1);

--- a/src/speedcompare/view-model.ts
+++ b/src/speedcompare/view-model.ts
@@ -1,0 +1,67 @@
+import type { Pokemon } from '../pokeinfo';
+import { calcActuals } from '../pokeinfo/stats';
+import { findMinimalReversal, Nature, ReversalResult } from './compare';
+import { effectiveSpeed } from './speed';
+
+export type AInput = {
+  name: string;
+  pokemon: Pokemon;
+  sp: number;
+  nature: Nature;
+};
+
+export type BInput = {
+  name: string;
+  pokemon: Pokemon;
+};
+
+export type RankReversal = {
+  rank: number;
+  result: ReversalResult;
+};
+
+export type SpeedCompareViewModel = {
+  aName: string;
+  aConfig: string;
+  aBase: number;
+  aSpeed: number;
+  bName: string;
+  bBase: number;
+  /** [速, 準, 無, 遅] の参考実数値 */
+  bReferenceSpeeds: [number, number, number, number];
+  reversals: RankReversal[];
+};
+
+const RANK_RANGE = [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6] as const;
+
+function formatNature(nature: Nature): string {
+  if (nature === 1.1) return '↑補正';
+  if (nature === 0.9) return '↓補正';
+  return '無補正';
+}
+
+export function buildSpeedCompareViewModel(input: {
+  a: AInput;
+  b: BInput;
+}): SpeedCompareViewModel {
+  const { a, b } = input;
+  const aSpeed = effectiveSpeed(a.pokemon.baseStats.S, a.sp, a.nature, 0);
+  const bBase = b.pokemon.baseStats.S;
+  const bActuals = calcActuals('S', bBase) as [number, number, number, number];
+
+  const reversals: RankReversal[] = RANK_RANGE.map((rank) => ({
+    rank,
+    result: findMinimalReversal(aSpeed, bBase, rank),
+  }));
+
+  return {
+    aName: a.name,
+    aConfig: `SP${a.sp} ${formatNature(a.nature)}`,
+    aBase: a.pokemon.baseStats.S,
+    aSpeed,
+    bName: b.name,
+    bBase,
+    bReferenceSpeeds: bActuals,
+    reversals,
+  };
+}

--- a/src/speedcompare/view-model.ts
+++ b/src/speedcompare/view-model.ts
@@ -1,6 +1,10 @@
 import type { Pokemon } from '../pokeinfo';
 import { calcActuals } from '../pokeinfo/stats';
-import { findMinimalReversal, Nature, ReversalResult } from './compare';
+import {
+  findMinimalReversal,
+  type Nature,
+  type ReversalResult,
+} from './compare';
 import { effectiveSpeed } from './speed';
 
 export type AInput = {


### PR DESCRIPTION
## Summary

- Pokémon Champions 対応: `pokeinfo/stats.ts` を従来EV (0/252振り) から Champions の SP (0〜32) 仕様に書き換え。概念・引数名・コメントを統一 (実数値の結果は従来と一致)。
- 新コマンド `/speedcompare` を追加。2体のポケモンを指定すると、B側の SP・性格・能力ランクを網羅的に探索し、A < B となる最小境界条件をランクごとに表示する。

## `/speedcompare` の使い方

| オプション | 必須 | 内容 |
|---|---|---|
| `a` | ✅ | ベースポケモンA（autocomplete） |
| `a_sp` | ✅ | AのSP (0〜32) |
| `a_nature` | ✅ | Aの性格補正（↑/無/↓） |
| `b` | ✅ | 仮想敵ポケモンB（autocomplete） |

補正換算: スカーフ = +1 / おいかぜ = +2 / まひ = -2 としてランクに吸収するため、オプションは不要。

## 出力サンプル

```
[A: テツノツツミ]
SP32 ↑補正
S種族値 136 → 実数値 206

[B: サーフゴー]
S種族値 84 → 実数値 149 / 136 / 104 / 93

[サーフゴーのランク別 逆転条件]
🔵 -6〜±0 テツノツツミ > サーフゴー
🟡 +1 サーフゴー SP22↑以上 → テツノツツミ < サーフゴー
🟡 +2 サーフゴー SP0以上 → テツノツツミ < サーフゴー
🔴 +3〜+6 テツノツツミ < サーフゴー
```

- 🔵 A常勝 / 🟡 逆転境界 / 🔴 A常敗 を色で識別
- 連続する同一結果はランク範囲にまとめる

## アーキテクチャ

`src/speedcompare/` 3レイヤー構成 (pokeinfo と同様):
- `speed.ts`: `rankMult` + `effectiveSpeed`（各段floorの整数演算）
- `compare.ts`: `findMinimalReversal` (always_a / always_b / threshold を返す)
- `view-model.ts` / `embed.ts`: 表示構築

## Test plan

- [x] `pnpm test` (56 tests passed)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] デプロイ後に `pnpm register-commands` を実行して Discord 側にコマンド登録
- [ ] Discord で実コマンドを叩いて出力確認
