### PR TITLE
feat(speedcompare): add "change B" button + modal resubmit

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import {
   APIApplicationCommandInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
+  APIModalSubmitInteraction,
 } from 'discord-api-types/v10';
 import DiscordApi from '../discord/api';
 import * as ping from './ping';
@@ -34,6 +35,9 @@ type Command = {
   ) => Promise<APIApplicationCommandAutocompleteResponse | null>;
   createComponentResponse?: (
     interaction: APIMessageComponentInteraction,
+  ) => Promise<ComponentResult | null>;
+  createModalSubmitResponse?: (
+    interaction: APIModalSubmitInteraction,
   ) => Promise<ComponentResult | null>;
 };
 

--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -1,14 +1,24 @@
 import {
+  APIActionRowComponent,
   APIApplicationCommandAutocompleteInteraction,
   APIApplicationCommandAutocompleteResponse,
   APIApplicationCommandInteraction,
+  APIComponentInMessageActionRow,
+  APIComponentInModalActionRow,
   APIInteractionResponse,
+  APIMessageComponentInteraction,
+  APIModalInteractionResponseCallbackData,
+  APIModalSubmitInteraction,
   ApplicationCommandOptionType,
   ApplicationCommandType,
+  ButtonStyle,
+  ComponentType,
   InteractionResponseType,
   MessageFlags,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
+  TextInputStyle,
 } from 'discord-api-types/v10';
+import { ComponentResult } from '.';
 import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
 import type { Nature } from '../speedcompare/compare';
 import { buildSpeedCompareViewModel } from '../speedcompare/view-model';
@@ -17,6 +27,10 @@ import { formatSpeedCompareEmbed } from '../speedcompare/embed';
 const NATURE_UP = 'up';
 const NATURE_NEUTRAL = 'neutral';
 const NATURE_DOWN = 'down';
+
+const CHANGE_B_ACTION = 'change_b';
+const SUBMIT_B_ACTION = 'submit_b';
+const MODAL_B_NAME_INPUT = 'b_name';
 
 export default {
   name: 'speedcompare',
@@ -58,10 +72,96 @@ export default {
   ],
 } satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
 
-function parseNature(value: string): Nature {
-  if (value === NATURE_UP) return 1.1;
-  if (value === NATURE_DOWN) return 0.9;
+function parseNature(code: string): Nature {
+  if (code === NATURE_UP) return 1.1;
+  if (code === NATURE_DOWN) return 0.9;
   return 1.0;
+}
+
+function natureCode(nature: Nature): string {
+  if (nature === 1.1) return NATURE_UP;
+  if (nature === 0.9) return NATURE_DOWN;
+  return NATURE_NEUTRAL;
+}
+
+function buildChangeBRow(
+  aName: string,
+  aSp: number,
+  aNature: Nature,
+): APIActionRowComponent<APIComponentInMessageActionRow> {
+  return {
+    type: ComponentType.ActionRow,
+    components: [
+      {
+        type: ComponentType.Button,
+        style: ButtonStyle.Secondary,
+        label: '🔁 Bを変えて再計算',
+        custom_id: `speedcompare:${CHANGE_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
+      },
+    ],
+  };
+}
+
+function buildChangeBModal(
+  aName: string,
+  aSp: number,
+  aNature: Nature,
+): APIModalInteractionResponseCallbackData {
+  const row: APIActionRowComponent<APIComponentInModalActionRow> = {
+    type: ComponentType.ActionRow,
+    components: [
+      {
+        type: ComponentType.TextInput,
+        custom_id: MODAL_B_NAME_INPUT,
+        label: 'ポケモンB名 (日本語正式名)',
+        style: TextInputStyle.Short,
+        required: true,
+        max_length: 32,
+      },
+    ],
+  };
+  return {
+    custom_id: `speedcompare:${SUBMIT_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
+    title: `vs ${aName} (SP${aSp} ${aNature === 1.1 ? '↑' : aNature === 0.9 ? '↓' : '無'})`,
+    components: [row],
+  };
+}
+
+async function renderResult(
+  aName: string,
+  aSp: number,
+  aNature: Nature,
+  bName: string,
+): Promise<APIInteractionResponse> {
+  const [aData, bData] = await Promise.all([
+    searchPokemonByName(aName),
+    searchPokemonByName(bName),
+  ]);
+  if (!aData || !bData) {
+    const missing = [!aData && `"${aName}"`, !bData && `"${bName}"`]
+      .filter(Boolean)
+      .join(' と ');
+    return {
+      type: InteractionResponseType.ChannelMessageWithSource,
+      data: {
+        content: `${missing} の情報は見つからなかったロトね...`,
+        flags: MessageFlags.Ephemeral,
+      },
+    };
+  }
+  const vm = buildSpeedCompareViewModel({
+    a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
+    b: { name: bName, pokemon: bData },
+  });
+  const embed = formatSpeedCompareEmbed(vm);
+  return {
+    type: InteractionResponseType.ChannelMessageWithSource,
+    data: {
+      embeds: [embed],
+      components: [buildChangeBRow(aName, aSp, aNature)],
+      flags: MessageFlags.Ephemeral,
+    },
+  };
 }
 
 export async function createResponse(
@@ -83,7 +183,6 @@ export async function createResponse(
   ) {
     return null;
   }
-
   const aName = aOpt.value;
   const aSp = spOpt.value;
   const aNature = parseNature(natureOpt.value);
@@ -91,36 +190,56 @@ export async function createResponse(
   console.log(
     `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
   );
+  return renderResult(aName, aSp, aNature, bName);
+}
 
-  const [aData, bData] = await Promise.all([
-    searchPokemonByName(aName),
-    searchPokemonByName(bName),
-  ]);
-  if (!aData || !bData) {
-    const missing = [!aData && `"${aName}"`, !bData && `"${bName}"`]
-      .filter(Boolean)
-      .join(' と ');
-    return {
-      type: InteractionResponseType.ChannelMessageWithSource,
-      data: {
-        content: `${missing} の情報は見つからなかったロトね...`,
-        flags: MessageFlags.Ephemeral,
-      },
-    };
+export async function createComponentResponse(
+  interaction: APIMessageComponentInteraction,
+): Promise<ComponentResult | null> {
+  const [, action, aName, aSpStr, aNatureCode] =
+    interaction.data.custom_id.split(':');
+  if (action !== CHANGE_B_ACTION || !aName || !aSpStr || !aNatureCode) {
+    return null;
   }
-
-  const vm = buildSpeedCompareViewModel({
-    a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
-    b: { name: bName, pokemon: bData },
-  });
-  const embed = formatSpeedCompareEmbed(vm);
+  const aSp = Number(aSpStr);
+  const aNature = parseNature(aNatureCode);
   return {
-    type: InteractionResponseType.ChannelMessageWithSource,
-    data: {
-      embeds: [embed],
-      flags: MessageFlags.Ephemeral,
+    response: {
+      type: InteractionResponseType.Modal,
+      data: buildChangeBModal(aName, aSp, aNature),
     },
   };
+}
+
+export async function createModalSubmitResponse(
+  interaction: APIModalSubmitInteraction,
+): Promise<ComponentResult | null> {
+  const [, action, aName, aSpStr, aNatureCode] =
+    interaction.data.custom_id.split(':');
+  if (action !== SUBMIT_B_ACTION || !aName || !aSpStr || !aNatureCode) {
+    return null;
+  }
+  const aSp = Number(aSpStr);
+  const aNature = parseNature(aNatureCode);
+  let bName: string | undefined;
+  for (const row of interaction.data.components) {
+    if (row.type !== ComponentType.ActionRow) continue;
+    for (const comp of row.components) {
+      if (
+        comp.type === ComponentType.TextInput &&
+        comp.custom_id === MODAL_B_NAME_INPUT
+      ) {
+        bName = comp.value;
+      }
+    }
+  }
+  if (!bName) {
+    return null;
+  }
+  console.log(
+    `[speedcompare:modal] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
+  );
+  return { response: await renderResult(aName, aSp, aNature, bName.trim()) };
 }
 
 export async function createAutocompleteResponse(

--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -229,7 +229,7 @@ export async function createModalSubmitResponse(
         comp.type === ComponentType.TextInput &&
         comp.custom_id === MODAL_B_NAME_INPUT
       ) {
-        bName = comp.value;
+        bName = comp.value.trim();
       }
     }
   }
@@ -239,7 +239,7 @@ export async function createModalSubmitResponse(
   console.log(
     `[speedcompare:modal] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
   );
-  return { response: await renderResult(aName, aSp, aNature, bName.trim()) };
+  return { response: await renderResult(aName, aSp, aNature, bName) };
 }
 
 export async function createAutocompleteResponse(

--- a/src/discord/interactions.ts
+++ b/src/discord/interactions.ts
@@ -4,6 +4,7 @@ import {
   APIInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
+  APIModalSubmitInteraction,
   InteractionResponseType,
   InteractionType,
 } from 'discord-api-types/v10';
@@ -56,6 +57,8 @@ export async function handleInteractionRequest(
       };
     case InteractionType.MessageComponent:
       return await handleMessageComponentInteraction(interaction);
+    case InteractionType.ModalSubmit:
+      return await handleModalSubmitInteraction(interaction);
   }
   throw new Error('Unknown interaction');
 }
@@ -95,5 +98,21 @@ async function handleMessageComponentInteraction(
     }
   }
   console.warn(`No handler for component custom_id: ${customId}`);
+  return { response: null };
+}
+
+async function handleModalSubmitInteraction(
+  interaction: APIModalSubmitInteraction,
+): Promise<InteractionResult> {
+  const customId = interaction.data.custom_id;
+  const [namespace] = customId.split(':');
+  const command = namespace ? getCommandByName(namespace) : undefined;
+  if (command && command.createModalSubmitResponse) {
+    const result = await command.createModalSubmitResponse(interaction);
+    if (result) {
+      return result;
+    }
+  }
+  console.warn(`No handler for modal custom_id: ${customId}`);
   return { response: null };
 }


### PR DESCRIPTION
## Summary

`/speedcompare` 実行後、Aポケモンの設定 (名前・SP・性格) を保ったままBだけを差し替えて再計算できる「🔁 Bを変えて再計算」ボタンを追加。

## フロー

1. `/speedcompare` → 結果Embed + 「🔁 Bを変えて再計算」ボタン (ephemeral)
2. ボタン押下 → B名入力のModalを表示
3. Modal submit → Aの情報はそのままに新しい結果を **追加のephemeralメッセージ** として投稿。元のメッセージは残る。

## 変更点

- `src/commands/index.ts` / `src/discord/interactions.ts`: `InteractionType.ModalSubmit` のディスパッチを追加 (Command型に `createModalSubmitResponse` を追加)
- `src/commands/speedcompare.ts`:
  - 結果レスポンスに「Bを変えて再計算」ボタンを付与
  - `createComponentResponse`: ボタン押下 → Modal 起動
  - `createModalSubmitResponse`: Modal受信 → 再計算して新しい ephemeral message を投稿
  - Aの状態はcustom_id (`speedcompare:{action}:{aName}:{aSp}:{aNatureCode}`) に埋め込み

## 制約

- Modal の text input には autocomplete がないため、B名は完全一致で手打ち必要（存在しなければ「見つからなかったロト」メッセージ）
- custom_id は100文字制限。日本語ポケモン名+数値+性格コードで十分収まる想定

## Test plan

- [x] `pnpm test` (56 tests passed)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] デプロイ後、Discordで `/speedcompare` を叩く
- [ ] 「🔁 Bを変えて再計算」ボタンを押してModalが開くことを確認
- [ ] Modal で別のBを入力 → 追加のephemeralメッセージとして新結果が表示されることを確認
- [ ] 元のメッセージが残っていることを確認
- [ ] 存在しないBを入力 → エラーメッセージが出ることを確認
