### PR TITLE
feat(speedcompare): history-sorted autocomplete for A/B inputs

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,8 +4,8 @@ import {
   APIApplicationCommandInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
+  APIModalSubmitInteraction,
 } from 'discord-api-types/v10';
-import { Env } from '../context';
 import DiscordApi from '../discord/api';
 import * as ping from './ping';
 import * as pokeinfo from './pokeinfo';
@@ -29,13 +29,15 @@ type Command = {
   };
   createResponse: (
     interaction: APIApplicationCommandInteraction,
-    env: Env,
   ) => Promise<APIInteractionResponse | null>;
   createAutocompleteResponse?: (
     interaction: APIApplicationCommandAutocompleteInteraction,
   ) => Promise<APIApplicationCommandAutocompleteResponse | null>;
   createComponentResponse?: (
     interaction: APIMessageComponentInteraction,
+  ) => Promise<ComponentResult | null>;
+  createModalSubmitResponse?: (
+    interaction: APIModalSubmitInteraction,
   ) => Promise<ComponentResult | null>;
 };
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,8 +4,8 @@ import {
   APIApplicationCommandInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
-  APIModalSubmitInteraction,
 } from 'discord-api-types/v10';
+import { Env } from '../context';
 import DiscordApi from '../discord/api';
 import * as ping from './ping';
 import * as pokeinfo from './pokeinfo';
@@ -29,15 +29,13 @@ type Command = {
   };
   createResponse: (
     interaction: APIApplicationCommandInteraction,
+    env: Env,
   ) => Promise<APIInteractionResponse | null>;
   createAutocompleteResponse?: (
     interaction: APIApplicationCommandAutocompleteInteraction,
   ) => Promise<APIApplicationCommandAutocompleteResponse | null>;
   createComponentResponse?: (
     interaction: APIMessageComponentInteraction,
-  ) => Promise<ComponentResult | null>;
-  createModalSubmitResponse?: (
-    interaction: APIModalSubmitInteraction,
   ) => Promise<ComponentResult | null>;
 };
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,8 +4,8 @@ import {
   APIApplicationCommandInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
-  APIModalSubmitInteraction,
 } from 'discord-api-types/v10';
+import { Env } from '../context';
 import DiscordApi from '../discord/api';
 import * as ping from './ping';
 import * as pokeinfo from './pokeinfo';
@@ -29,15 +29,14 @@ type Command = {
   };
   createResponse: (
     interaction: APIApplicationCommandInteraction,
+    env: Env,
   ) => Promise<APIInteractionResponse | null>;
   createAutocompleteResponse?: (
     interaction: APIApplicationCommandAutocompleteInteraction,
+    env: Env,
   ) => Promise<APIApplicationCommandAutocompleteResponse | null>;
   createComponentResponse?: (
     interaction: APIMessageComponentInteraction,
-  ) => Promise<ComponentResult | null>;
-  createModalSubmitResponse?: (
-    interaction: APIModalSubmitInteraction,
   ) => Promise<ComponentResult | null>;
 };
 

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -12,6 +12,7 @@ export default {
 
 export async function createResponse(
   _interaction: APIApplicationCommandInteraction,
+  _env: unknown,
 ): Promise<APIInteractionResponse> {
   return {
     type: InteractionResponseType.ChannelMessageWithSource,

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -4,6 +4,7 @@ import {
   InteractionResponseType,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
+import { Env } from '../context';
 
 export default {
   name: 'ping',
@@ -12,7 +13,7 @@ export default {
 
 export async function createResponse(
   _interaction: APIApplicationCommandInteraction,
-  _env: unknown,
+  _env: Env,
 ): Promise<APIInteractionResponse> {
   return {
     type: InteractionResponseType.ChannelMessageWithSource,

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -12,7 +12,6 @@ export default {
 
 export async function createResponse(
   _interaction: APIApplicationCommandInteraction,
-  _env: unknown,
 ): Promise<APIInteractionResponse> {
   return {
     type: InteractionResponseType.ChannelMessageWithSource,

--- a/src/commands/pokeinfo.test.ts
+++ b/src/commands/pokeinfo.test.ts
@@ -66,10 +66,7 @@ function buildComponentInteraction(
 
 describe('createResponse', () => {
   test('known pokemon returns ephemeral embed with share button', async () => {
-    const res = await createResponse(
-      buildSlashInteraction('ピカチュウ'),
-      {} as never,
-    );
+    const res = await createResponse(buildSlashInteraction('ピカチュウ'));
     expect(res).not.toBeNull();
     expect(res!.type).toBe(InteractionResponseType.ChannelMessageWithSource);
     const data = (res as { data: Record<string, unknown> }).data;
@@ -85,10 +82,7 @@ describe('createResponse', () => {
   });
 
   test('unknown pokemon returns ephemeral text without button', async () => {
-    const res = await createResponse(
-      buildSlashInteraction('__nope__'),
-      {} as never,
-    );
+    const res = await createResponse(buildSlashInteraction('__nope__'));
     expect(res).not.toBeNull();
     const data = (res as { data: Record<string, unknown> }).data;
     expect(data.flags).toBe(MessageFlags.Ephemeral);

--- a/src/commands/pokeinfo.test.ts
+++ b/src/commands/pokeinfo.test.ts
@@ -66,7 +66,10 @@ function buildComponentInteraction(
 
 describe('createResponse', () => {
   test('known pokemon returns ephemeral embed with share button', async () => {
-    const res = await createResponse(buildSlashInteraction('ピカチュウ'));
+    const res = await createResponse(
+      buildSlashInteraction('ピカチュウ'),
+      {} as never,
+    );
     expect(res).not.toBeNull();
     expect(res!.type).toBe(InteractionResponseType.ChannelMessageWithSource);
     const data = (res as { data: Record<string, unknown> }).data;
@@ -82,7 +85,10 @@ describe('createResponse', () => {
   });
 
   test('unknown pokemon returns ephemeral text without button', async () => {
-    const res = await createResponse(buildSlashInteraction('__nope__'));
+    const res = await createResponse(
+      buildSlashInteraction('__nope__'),
+      {} as never,
+    );
     expect(res).not.toBeNull();
     const data = (res as { data: Record<string, unknown> }).data;
     expect(data.flags).toBe(MessageFlags.Ephemeral);

--- a/src/commands/pokeinfo.ts
+++ b/src/commands/pokeinfo.ts
@@ -38,7 +38,6 @@ const SHARE_ACTION = 'share';
 
 export async function createResponse(
   interaction: APIApplicationCommandInteraction,
-  _env: unknown,
 ): Promise<APIInteractionResponse | null> {
   if (interaction.data.type !== ApplicationCommandType.ChatInput) {
     return null;

--- a/src/commands/pokeinfo.ts
+++ b/src/commands/pokeinfo.ts
@@ -38,6 +38,7 @@ const SHARE_ACTION = 'share';
 
 export async function createResponse(
   interaction: APIApplicationCommandInteraction,
+  _env: unknown,
 ): Promise<APIInteractionResponse | null> {
   if (interaction.data.type !== ApplicationCommandType.ChatInput) {
     return null;

--- a/src/commands/pokeinfo.ts
+++ b/src/commands/pokeinfo.ts
@@ -16,6 +16,7 @@ import {
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
 import { ComponentResult } from '.';
+import { Env } from '../context';
 import { buildPokemonViewModel } from '../pokeinfo/view-model';
 import { formatPokemonEmbed } from '../pokeinfo/embed';
 import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
@@ -38,7 +39,7 @@ const SHARE_ACTION = 'share';
 
 export async function createResponse(
   interaction: APIApplicationCommandInteraction,
-  _env: unknown,
+  _env: Env,
 ): Promise<APIInteractionResponse | null> {
   if (interaction.data.type !== ApplicationCommandType.ChatInput) {
     return null;
@@ -131,7 +132,7 @@ export async function createComponentResponse(
 
 export async function createAutocompleteResponse(
   interaction: APIApplicationCommandAutocompleteInteraction,
-  _env: unknown,
+  _env: Env,
 ): Promise<APIApplicationCommandAutocompleteResponse | null> {
   const focusedValue = interaction.data.options.find(
     (option) =>

--- a/src/commands/pokeinfo.ts
+++ b/src/commands/pokeinfo.ts
@@ -38,6 +38,7 @@ const SHARE_ACTION = 'share';
 
 export async function createResponse(
   interaction: APIApplicationCommandInteraction,
+  _env: unknown,
 ): Promise<APIInteractionResponse | null> {
   if (interaction.data.type !== ApplicationCommandType.ChatInput) {
     return null;
@@ -130,6 +131,7 @@ export async function createComponentResponse(
 
 export async function createAutocompleteResponse(
   interaction: APIApplicationCommandAutocompleteInteraction,
+  _env: unknown,
 ): Promise<APIApplicationCommandAutocompleteResponse | null> {
   const focusedValue = interaction.data.options.find(
     (option) =>

--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -1,16 +1,24 @@
 import {
+  APIActionRowComponent,
   APIApplicationCommandAutocompleteInteraction,
   APIApplicationCommandAutocompleteResponse,
   APIApplicationCommandInteraction,
-  APIInteraction,
+  APIComponentInMessageActionRow,
+  APIComponentInModalActionRow,
   APIInteractionResponse,
+  APIMessageComponentInteraction,
+  APIModalInteractionResponseCallbackData,
+  APIModalSubmitInteraction,
   ApplicationCommandOptionType,
   ApplicationCommandType,
+  ButtonStyle,
+  ComponentType,
   InteractionResponseType,
   MessageFlags,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
+  TextInputStyle,
 } from 'discord-api-types/v10';
-import { Env } from '../context';
+import { ComponentResult } from '.';
 import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
 import type { Nature } from '../speedcompare/compare';
 import { buildSpeedCompareViewModel } from '../speedcompare/view-model';
@@ -20,152 +28,111 @@ const NATURE_UP = 'up';
 const NATURE_NEUTRAL = 'neutral';
 const NATURE_DOWN = 'down';
 
-type NatureCode = typeof NATURE_UP | typeof NATURE_NEUTRAL | typeof NATURE_DOWN;
-
-type AState = {
-  aName: string;
-  aSp: number;
-  aNature: NatureCode;
-};
-
-const STATE_TTL_SECONDS = 60 * 60 * 24; // 1日
+const CHANGE_B_ACTION = 'change_b';
+const SUBMIT_B_ACTION = 'submit_b';
+const MODAL_B_NAME_INPUT = 'b_name';
 
 export default {
   name: 'speedcompare',
-  description:
-    'ベースポケモンAと仮想敵Bのすばやさ関係を分析します (Aは前回の入力が保持される)',
+  description: 'ベースポケモンAと仮想敵Bのすばやさ関係を分析します',
   options: [
     {
-      name: 'b',
-      description: '仮想敵ポケモンB (必須)',
+      name: 'a',
+      description: 'ベースポケモンA（自分側）',
       type: ApplicationCommandOptionType.String,
       required: true,
       autocomplete: true,
     },
     {
-      name: 'a',
-      description: 'ベースポケモンA (省略時は前回の入力を使用)',
-      type: ApplicationCommandOptionType.String,
-      required: false,
-      autocomplete: true,
-    },
-    {
       name: 'a_sp',
-      description: 'Aの素早さSP 0〜32 (省略時は前回の入力を使用)',
+      description: 'Aの素早さSP (0〜32)',
       type: ApplicationCommandOptionType.Integer,
-      required: false,
+      required: true,
       min_value: 0,
       max_value: 32,
     },
     {
       name: 'a_nature',
-      description: 'Aの性格補正 (省略時は前回の入力を使用)',
+      description: 'Aの性格補正',
       type: ApplicationCommandOptionType.String,
-      required: false,
+      required: true,
       choices: [
         { name: '↑補正', value: NATURE_UP },
         { name: '無補正', value: NATURE_NEUTRAL },
         { name: '↓補正', value: NATURE_DOWN },
       ],
     },
+    {
+      name: 'b',
+      description: '仮想敵ポケモンB',
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: true,
+    },
   ],
 } satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
 
-function parseNature(code: NatureCode): Nature {
+function parseNature(code: string): Nature {
   if (code === NATURE_UP) return 1.1;
   if (code === NATURE_DOWN) return 0.9;
   return 1.0;
 }
 
-function getUserId(interaction: APIInteraction): string | null {
-  return interaction.member?.user.id ?? interaction.user?.id ?? null;
+function natureCode(nature: Nature): string {
+  if (nature === 1.1) return NATURE_UP;
+  if (nature === 0.9) return NATURE_DOWN;
+  return NATURE_NEUTRAL;
 }
 
-function stateKey(userId: string): string {
-  return `sc:a:${userId}`;
-}
-
-async function loadState(
-  env: Env,
-  userId: string,
-): Promise<AState | null> {
-  const raw = await env.NEWS_KV.get(stateKey(userId));
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as AState;
-  } catch {
-    return null;
-  }
-}
-
-async function saveState(
-  env: Env,
-  userId: string,
-  state: AState,
-): Promise<void> {
-  await env.NEWS_KV.put(stateKey(userId), JSON.stringify(state), {
-    expirationTtl: STATE_TTL_SECONDS,
-  });
-}
-
-export async function createResponse(
-  interaction: APIApplicationCommandInteraction,
-  env: Env,
-): Promise<APIInteractionResponse | null> {
-  if (interaction.data.type !== ApplicationCommandType.ChatInput) {
-    return null;
-  }
-  const options = interaction.data.options ?? [];
-  const aOpt = options.find((o) => o.name === 'a');
-  const spOpt = options.find((o) => o.name === 'a_sp');
-  const natureOpt = options.find((o) => o.name === 'a_nature');
-  const bOpt = options.find((o) => o.name === 'b');
-  if (bOpt?.type !== ApplicationCommandOptionType.String) {
-    return null;
-  }
-
-  const userId = getUserId(interaction);
-  const stored = userId ? await loadState(env, userId) : null;
-
-  const aNameIn =
-    aOpt?.type === ApplicationCommandOptionType.String ? aOpt.value : undefined;
-  const aSpIn =
-    spOpt?.type === ApplicationCommandOptionType.Integer
-      ? spOpt.value
-      : undefined;
-  const aNatureIn =
-    natureOpt?.type === ApplicationCommandOptionType.String
-      ? (natureOpt.value as NatureCode)
-      : undefined;
-
-  const aName = aNameIn ?? stored?.aName;
-  const aSp = aSpIn ?? stored?.aSp;
-  const aNatureCode = aNatureIn ?? stored?.aNature;
-
-  if (aName === undefined || aSp === undefined || aNatureCode === undefined) {
-    const missing = [
-      aName === undefined && '`a`',
-      aSp === undefined && '`a_sp`',
-      aNatureCode === undefined && '`a_nature`',
-    ]
-      .filter(Boolean)
-      .join(', ');
-    return {
-      type: InteractionResponseType.ChannelMessageWithSource,
-      data: {
-        content:
-          `初回利用は ${missing} も指定してくださいロト。次回からは \`b\` だけで計算できるようになるロト！`,
-        flags: MessageFlags.Ephemeral,
+function buildChangeBRow(
+  aName: string,
+  aSp: number,
+  aNature: Nature,
+): APIActionRowComponent<APIComponentInMessageActionRow> {
+  return {
+    type: ComponentType.ActionRow,
+    components: [
+      {
+        type: ComponentType.Button,
+        style: ButtonStyle.Secondary,
+        label: '🔁 Bを変えて再計算',
+        custom_id: `speedcompare:${CHANGE_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
       },
-    };
-  }
+    ],
+  };
+}
 
-  const aNature = parseNature(aNatureCode);
-  const bName = bOpt.value;
-  console.log(
-    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName} (user=${userId})`,
-  );
+function buildChangeBModal(
+  aName: string,
+  aSp: number,
+  aNature: Nature,
+): APIModalInteractionResponseCallbackData {
+  const row: APIActionRowComponent<APIComponentInModalActionRow> = {
+    type: ComponentType.ActionRow,
+    components: [
+      {
+        type: ComponentType.TextInput,
+        custom_id: MODAL_B_NAME_INPUT,
+        label: 'ポケモンB名 (日本語正式名)',
+        style: TextInputStyle.Short,
+        required: true,
+        max_length: 32,
+      },
+    ],
+  };
+  return {
+    custom_id: `speedcompare:${SUBMIT_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
+    title: `vs ${aName} (SP${aSp} ${aNature === 1.1 ? '↑' : aNature === 0.9 ? '↓' : '無'})`,
+    components: [row],
+  };
+}
 
+async function renderResult(
+  aName: string,
+  aSp: number,
+  aNature: Nature,
+  bName: string,
+): Promise<APIInteractionResponse> {
   const [aData, bData] = await Promise.all([
     searchPokemonByName(aName),
     searchPokemonByName(bName),
@@ -182,15 +149,6 @@ export async function createResponse(
       },
     };
   }
-
-  if (userId) {
-    await saveState(env, userId, {
-      aName,
-      aSp,
-      aNature: aNatureCode,
-    });
-  }
-
   const vm = buildSpeedCompareViewModel({
     a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
     b: { name: bName, pokemon: bData },
@@ -200,9 +158,88 @@ export async function createResponse(
     type: InteractionResponseType.ChannelMessageWithSource,
     data: {
       embeds: [embed],
+      components: [buildChangeBRow(aName, aSp, aNature)],
       flags: MessageFlags.Ephemeral,
     },
   };
+}
+
+export async function createResponse(
+  interaction: APIApplicationCommandInteraction,
+): Promise<APIInteractionResponse | null> {
+  if (interaction.data.type !== ApplicationCommandType.ChatInput) {
+    return null;
+  }
+  const options = interaction.data.options ?? [];
+  const aOpt = options.find((o) => o.name === 'a');
+  const spOpt = options.find((o) => o.name === 'a_sp');
+  const natureOpt = options.find((o) => o.name === 'a_nature');
+  const bOpt = options.find((o) => o.name === 'b');
+  if (
+    aOpt?.type !== ApplicationCommandOptionType.String ||
+    spOpt?.type !== ApplicationCommandOptionType.Integer ||
+    natureOpt?.type !== ApplicationCommandOptionType.String ||
+    bOpt?.type !== ApplicationCommandOptionType.String
+  ) {
+    return null;
+  }
+  const aName = aOpt.value;
+  const aSp = spOpt.value;
+  const aNature = parseNature(natureOpt.value);
+  const bName = bOpt.value;
+  console.log(
+    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
+  );
+  return renderResult(aName, aSp, aNature, bName);
+}
+
+export async function createComponentResponse(
+  interaction: APIMessageComponentInteraction,
+): Promise<ComponentResult | null> {
+  const [, action, aName, aSpStr, aNatureCode] =
+    interaction.data.custom_id.split(':');
+  if (action !== CHANGE_B_ACTION || !aName || !aSpStr || !aNatureCode) {
+    return null;
+  }
+  const aSp = Number(aSpStr);
+  const aNature = parseNature(aNatureCode);
+  return {
+    response: {
+      type: InteractionResponseType.Modal,
+      data: buildChangeBModal(aName, aSp, aNature),
+    },
+  };
+}
+
+export async function createModalSubmitResponse(
+  interaction: APIModalSubmitInteraction,
+): Promise<ComponentResult | null> {
+  const [, action, aName, aSpStr, aNatureCode] =
+    interaction.data.custom_id.split(':');
+  if (action !== SUBMIT_B_ACTION || !aName || !aSpStr || !aNatureCode) {
+    return null;
+  }
+  const aSp = Number(aSpStr);
+  const aNature = parseNature(aNatureCode);
+  let bName: string | undefined;
+  for (const row of interaction.data.components) {
+    if (row.type !== ComponentType.ActionRow) continue;
+    for (const comp of row.components) {
+      if (
+        comp.type === ComponentType.TextInput &&
+        comp.custom_id === MODAL_B_NAME_INPUT
+      ) {
+        bName = comp.value.trim();
+      }
+    }
+  }
+  if (!bName) {
+    return null;
+  }
+  console.log(
+    `[speedcompare:modal] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
+  );
+  return { response: await renderResult(aName, aSp, aNature, bName) };
 }
 
 export async function createAutocompleteResponse(

--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -1,24 +1,16 @@
 import {
-  APIActionRowComponent,
   APIApplicationCommandAutocompleteInteraction,
   APIApplicationCommandAutocompleteResponse,
   APIApplicationCommandInteraction,
-  APIComponentInMessageActionRow,
-  APIComponentInModalActionRow,
+  APIInteraction,
   APIInteractionResponse,
-  APIMessageComponentInteraction,
-  APIModalInteractionResponseCallbackData,
-  APIModalSubmitInteraction,
   ApplicationCommandOptionType,
   ApplicationCommandType,
-  ButtonStyle,
-  ComponentType,
   InteractionResponseType,
   MessageFlags,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
-  TextInputStyle,
 } from 'discord-api-types/v10';
-import { ComponentResult } from '.';
+import { Env } from '../context';
 import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
 import type { Nature } from '../speedcompare/compare';
 import { buildSpeedCompareViewModel } from '../speedcompare/view-model';
@@ -28,9 +20,16 @@ const NATURE_UP = 'up';
 const NATURE_NEUTRAL = 'neutral';
 const NATURE_DOWN = 'down';
 
-const CHANGE_B_ACTION = 'change_b';
-const SUBMIT_B_ACTION = 'submit_b';
-const MODAL_B_NAME_INPUT = 'b_name';
+type History = {
+  a: string[];
+  aSp: number[];
+  b: string[];
+};
+
+const HISTORY_LIMIT = 10;
+const HISTORY_TTL_SECONDS = 60 * 60 * 24 * 30; // 30日
+const AUTOCOMPLETE_LIMIT = 25;
+const TYPICAL_SP_VALUES = [0, 4, 12, 20, 28, 32];
 
 export default {
   name: 'speedcompare',
@@ -38,18 +37,20 @@ export default {
   options: [
     {
       name: 'a',
-      description: 'ベースポケモンA（自分側）',
+      description:
+        'ベースポケモンA（直近使用したポケモンが上位に表示されます）',
       type: ApplicationCommandOptionType.String,
       required: true,
       autocomplete: true,
     },
     {
       name: 'a_sp',
-      description: 'Aの素早さSP (0〜32)',
+      description: 'Aの素早さSP (0〜32、直近使用値が上位に表示されます)',
       type: ApplicationCommandOptionType.Integer,
       required: true,
       min_value: 0,
       max_value: 32,
+      autocomplete: true,
     },
     {
       name: 'a_nature',
@@ -64,7 +65,8 @@ export default {
     },
     {
       name: 'b',
-      description: '仮想敵ポケモンB',
+      description:
+        '仮想敵ポケモンB（直近使用したポケモンが上位に表示されます）',
       type: ApplicationCommandOptionType.String,
       required: true,
       autocomplete: true,
@@ -72,100 +74,65 @@ export default {
   ],
 } satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
 
-function parseNature(code: string): Nature {
-  if (code === NATURE_UP) return 1.1;
-  if (code === NATURE_DOWN) return 0.9;
+function parseNature(value: string): Nature {
+  if (value === NATURE_UP) return 1.1;
+  if (value === NATURE_DOWN) return 0.9;
   return 1.0;
 }
 
-function natureCode(nature: Nature): string {
-  if (nature === 1.1) return NATURE_UP;
-  if (nature === 0.9) return NATURE_DOWN;
-  return NATURE_NEUTRAL;
+function getUserId(interaction: APIInteraction): string | null {
+  return interaction.member?.user.id ?? interaction.user?.id ?? null;
 }
 
-function buildChangeBRow(
-  aName: string,
-  aSp: number,
-  aNature: Nature,
-): APIActionRowComponent<APIComponentInMessageActionRow> {
-  return {
-    type: ComponentType.ActionRow,
-    components: [
-      {
-        type: ComponentType.Button,
-        style: ButtonStyle.Secondary,
-        label: '🔁 Bを変えて再計算',
-        custom_id: `speedcompare:${CHANGE_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
-      },
-    ],
-  };
+function historyKey(userId: string): string {
+  return `sc:history:${userId}`;
 }
 
-function buildChangeBModal(
-  aName: string,
-  aSp: number,
-  aNature: Nature,
-): APIModalInteractionResponseCallbackData {
-  const row: APIActionRowComponent<APIComponentInModalActionRow> = {
-    type: ComponentType.ActionRow,
-    components: [
-      {
-        type: ComponentType.TextInput,
-        custom_id: MODAL_B_NAME_INPUT,
-        label: 'ポケモンB名 (日本語正式名)',
-        style: TextInputStyle.Short,
-        required: true,
-        max_length: 32,
-      },
-    ],
-  };
-  return {
-    custom_id: `speedcompare:${SUBMIT_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
-    title: `vs ${aName} (SP${aSp} ${aNature === 1.1 ? '↑' : aNature === 0.9 ? '↓' : '無'})`,
-    components: [row],
-  };
+function emptyHistory(): History {
+  return { a: [], aSp: [], b: [] };
 }
 
-async function renderResult(
-  aName: string,
-  aSp: number,
-  aNature: Nature,
-  bName: string,
-): Promise<APIInteractionResponse> {
-  const [aData, bData] = await Promise.all([
-    searchPokemonByName(aName),
-    searchPokemonByName(bName),
-  ]);
-  if (!aData || !bData) {
-    const missing = [!aData && `"${aName}"`, !bData && `"${bName}"`]
-      .filter(Boolean)
-      .join(' と ');
+async function loadHistory(env: Env, userId: string): Promise<History> {
+  const raw = await env.SPEEDCOMPARE_KV.get(historyKey(userId));
+  if (!raw) return emptyHistory();
+  try {
+    const parsed = JSON.parse(raw) as Partial<History>;
     return {
-      type: InteractionResponseType.ChannelMessageWithSource,
-      data: {
-        content: `${missing} の情報は見つからなかったロトね...`,
-        flags: MessageFlags.Ephemeral,
-      },
+      a: Array.isArray(parsed.a) ? parsed.a : [],
+      aSp: Array.isArray(parsed.aSp) ? parsed.aSp : [],
+      b: Array.isArray(parsed.b) ? parsed.b : [],
     };
+  } catch {
+    return emptyHistory();
   }
-  const vm = buildSpeedCompareViewModel({
-    a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
-    b: { name: bName, pokemon: bData },
+}
+
+async function saveHistory(
+  env: Env,
+  userId: string,
+  history: History,
+): Promise<void> {
+  await env.SPEEDCOMPARE_KV.put(historyKey(userId), JSON.stringify(history), {
+    expirationTtl: HISTORY_TTL_SECONDS,
   });
-  const embed = formatSpeedCompareEmbed(vm);
-  return {
-    type: InteractionResponseType.ChannelMessageWithSource,
-    data: {
-      embeds: [embed],
-      components: [buildChangeBRow(aName, aSp, aNature)],
-      flags: MessageFlags.Ephemeral,
-    },
-  };
+}
+
+function pushHistory<T>(list: T[], value: T): T[] {
+  return [value, ...list.filter((v) => v !== value)].slice(0, HISTORY_LIMIT);
+}
+
+/** 候補リストを、historyにある値を上位にくるよう並び替える (重複なし) */
+function sortByHistory<T>(choices: T[], history: T[]): T[] {
+  const choiceSet = new Set(choices);
+  const historyPart = history.filter((v) => choiceSet.has(v));
+  const historySet = new Set(historyPart);
+  const restPart = choices.filter((v) => !historySet.has(v));
+  return [...historyPart, ...restPart];
 }
 
 export async function createResponse(
   interaction: APIApplicationCommandInteraction,
+  env: Env,
 ): Promise<APIInteractionResponse | null> {
   if (interaction.data.type !== ApplicationCommandType.ChatInput) {
     return null;
@@ -187,78 +154,101 @@ export async function createResponse(
   const aSp = spOpt.value;
   const aNature = parseNature(natureOpt.value);
   const bName = bOpt.value;
+  const userId = getUserId(interaction);
   console.log(
-    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
+    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName} (user=${userId})`,
   );
-  return renderResult(aName, aSp, aNature, bName);
-}
 
-export async function createComponentResponse(
-  interaction: APIMessageComponentInteraction,
-): Promise<ComponentResult | null> {
-  const [, action, aName, aSpStr, aNatureCode] =
-    interaction.data.custom_id.split(':');
-  if (action !== CHANGE_B_ACTION || !aName || !aSpStr || !aNatureCode) {
-    return null;
+  const [aData, bData] = await Promise.all([
+    searchPokemonByName(aName),
+    searchPokemonByName(bName),
+  ]);
+  if (!aData || !bData) {
+    const missing = [!aData && `"${aName}"`, !bData && `"${bName}"`]
+      .filter(Boolean)
+      .join(' と ');
+    return {
+      type: InteractionResponseType.ChannelMessageWithSource,
+      data: {
+        content: `${missing} の情報は見つからなかったロトね...`,
+        flags: MessageFlags.Ephemeral,
+      },
+    };
   }
-  const aSp = Number(aSpStr);
-  const aNature = parseNature(aNatureCode);
+
+  if (userId) {
+    const prev = await loadHistory(env, userId);
+    const next: History = {
+      a: pushHistory(prev.a, aName),
+      aSp: pushHistory(prev.aSp, aSp),
+      b: pushHistory(prev.b, bName),
+    };
+    await saveHistory(env, userId, next);
+  }
+
+  const vm = buildSpeedCompareViewModel({
+    a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
+    b: { name: bName, pokemon: bData },
+  });
+  const embed = formatSpeedCompareEmbed(vm);
   return {
-    response: {
-      type: InteractionResponseType.Modal,
-      data: buildChangeBModal(aName, aSp, aNature),
+    type: InteractionResponseType.ChannelMessageWithSource,
+    data: {
+      embeds: [embed],
+      flags: MessageFlags.Ephemeral,
     },
   };
-}
-
-export async function createModalSubmitResponse(
-  interaction: APIModalSubmitInteraction,
-): Promise<ComponentResult | null> {
-  const [, action, aName, aSpStr, aNatureCode] =
-    interaction.data.custom_id.split(':');
-  if (action !== SUBMIT_B_ACTION || !aName || !aSpStr || !aNatureCode) {
-    return null;
-  }
-  const aSp = Number(aSpStr);
-  const aNature = parseNature(aNatureCode);
-  let bName: string | undefined;
-  for (const row of interaction.data.components) {
-    if (row.type !== ComponentType.ActionRow) continue;
-    for (const comp of row.components) {
-      if (
-        comp.type === ComponentType.TextInput &&
-        comp.custom_id === MODAL_B_NAME_INPUT
-      ) {
-        bName = comp.value.trim();
-      }
-    }
-  }
-  if (!bName) {
-    return null;
-  }
-  console.log(
-    `[speedcompare:modal] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
-  );
-  return { response: await renderResult(aName, aSp, aNature, bName) };
 }
 
 export async function createAutocompleteResponse(
   interaction: APIApplicationCommandAutocompleteInteraction,
+  env: Env,
 ): Promise<APIApplicationCommandAutocompleteResponse | null> {
   const focused = interaction.data.options.find(
-    (o) => o.type === ApplicationCommandOptionType.String && o.focused,
+    (o) =>
+      (o.type === ApplicationCommandOptionType.String ||
+        o.type === ApplicationCommandOptionType.Integer) &&
+      o.focused,
   );
-  if (!focused || focused.type !== ApplicationCommandOptionType.String) {
-    return null;
+  if (!focused) return null;
+
+  const userId = getUserId(interaction);
+  const history = userId ? await loadHistory(env, userId) : emptyHistory();
+
+  if (
+    focused.type === ApplicationCommandOptionType.String &&
+    (focused.name === 'a' || focused.name === 'b')
+  ) {
+    const query = focused.value;
+    const hits = await getAllPokemonNames({ prefix: query });
+    const histList = focused.name === 'a' ? history.a : history.b;
+    const sorted = sortByHistory(hits, histList).slice(0, AUTOCOMPLETE_LIMIT);
+    return {
+      type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+      data: {
+        choices: sorted.map((c) => ({ name: c, value: c })),
+      },
+    };
   }
-  if (focused.name !== 'a' && focused.name !== 'b') {
-    return null;
+
+  if (
+    focused.type === ApplicationCommandOptionType.Integer &&
+    focused.name === 'a_sp'
+  ) {
+    const candidates = Array.from(
+      new Set([...history.aSp, ...TYPICAL_SP_VALUES]),
+    ).filter((n) => n >= 0 && n <= 32);
+    const sorted = sortByHistory(candidates, history.aSp).slice(
+      0,
+      AUTOCOMPLETE_LIMIT,
+    );
+    return {
+      type: InteractionResponseType.ApplicationCommandAutocompleteResult,
+      data: {
+        choices: sorted.map((n) => ({ name: String(n), value: n })),
+      },
+    };
   }
-  const choices = await getAllPokemonNames({ prefix: focused.value });
-  return {
-    type: InteractionResponseType.ApplicationCommandAutocompleteResult,
-    data: {
-      choices: choices.slice(0, 25).map((c) => ({ name: c, value: c })),
-    },
-  };
+
+  return null;
 }

--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -1,24 +1,16 @@
 import {
-  APIActionRowComponent,
   APIApplicationCommandAutocompleteInteraction,
   APIApplicationCommandAutocompleteResponse,
   APIApplicationCommandInteraction,
-  APIComponentInMessageActionRow,
-  APIComponentInModalActionRow,
+  APIInteraction,
   APIInteractionResponse,
-  APIMessageComponentInteraction,
-  APIModalInteractionResponseCallbackData,
-  APIModalSubmitInteraction,
   ApplicationCommandOptionType,
   ApplicationCommandType,
-  ButtonStyle,
-  ComponentType,
   InteractionResponseType,
   MessageFlags,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
-  TextInputStyle,
 } from 'discord-api-types/v10';
-import { ComponentResult } from '.';
+import { Env } from '../context';
 import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
 import type { Nature } from '../speedcompare/compare';
 import { buildSpeedCompareViewModel } from '../speedcompare/view-model';
@@ -28,111 +20,152 @@ const NATURE_UP = 'up';
 const NATURE_NEUTRAL = 'neutral';
 const NATURE_DOWN = 'down';
 
-const CHANGE_B_ACTION = 'change_b';
-const SUBMIT_B_ACTION = 'submit_b';
-const MODAL_B_NAME_INPUT = 'b_name';
+type NatureCode = typeof NATURE_UP | typeof NATURE_NEUTRAL | typeof NATURE_DOWN;
+
+type AState = {
+  aName: string;
+  aSp: number;
+  aNature: NatureCode;
+};
+
+const STATE_TTL_SECONDS = 60 * 60 * 24; // 1日
 
 export default {
   name: 'speedcompare',
-  description: 'ベースポケモンAと仮想敵Bのすばやさ関係を分析します',
+  description:
+    'ベースポケモンAと仮想敵Bのすばやさ関係を分析します (Aは前回の入力が保持される)',
   options: [
     {
-      name: 'a',
-      description: 'ベースポケモンA（自分側）',
+      name: 'b',
+      description: '仮想敵ポケモンB (必須)',
       type: ApplicationCommandOptionType.String,
       required: true,
       autocomplete: true,
     },
     {
+      name: 'a',
+      description: 'ベースポケモンA (省略時は前回の入力を使用)',
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: true,
+    },
+    {
       name: 'a_sp',
-      description: 'Aの素早さSP (0〜32)',
+      description: 'Aの素早さSP 0〜32 (省略時は前回の入力を使用)',
       type: ApplicationCommandOptionType.Integer,
-      required: true,
+      required: false,
       min_value: 0,
       max_value: 32,
     },
     {
       name: 'a_nature',
-      description: 'Aの性格補正',
+      description: 'Aの性格補正 (省略時は前回の入力を使用)',
       type: ApplicationCommandOptionType.String,
-      required: true,
+      required: false,
       choices: [
         { name: '↑補正', value: NATURE_UP },
         { name: '無補正', value: NATURE_NEUTRAL },
         { name: '↓補正', value: NATURE_DOWN },
       ],
     },
-    {
-      name: 'b',
-      description: '仮想敵ポケモンB',
-      type: ApplicationCommandOptionType.String,
-      required: true,
-      autocomplete: true,
-    },
   ],
 } satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
 
-function parseNature(code: string): Nature {
+function parseNature(code: NatureCode): Nature {
   if (code === NATURE_UP) return 1.1;
   if (code === NATURE_DOWN) return 0.9;
   return 1.0;
 }
 
-function natureCode(nature: Nature): string {
-  if (nature === 1.1) return NATURE_UP;
-  if (nature === 0.9) return NATURE_DOWN;
-  return NATURE_NEUTRAL;
+function getUserId(interaction: APIInteraction): string | null {
+  return interaction.member?.user.id ?? interaction.user?.id ?? null;
 }
 
-function buildChangeBRow(
-  aName: string,
-  aSp: number,
-  aNature: Nature,
-): APIActionRowComponent<APIComponentInMessageActionRow> {
-  return {
-    type: ComponentType.ActionRow,
-    components: [
-      {
-        type: ComponentType.Button,
-        style: ButtonStyle.Secondary,
-        label: '🔁 Bを変えて再計算',
-        custom_id: `speedcompare:${CHANGE_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
+function stateKey(userId: string): string {
+  return `sc:a:${userId}`;
+}
+
+async function loadState(
+  env: Env,
+  userId: string,
+): Promise<AState | null> {
+  const raw = await env.NEWS_KV.get(stateKey(userId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AState;
+  } catch {
+    return null;
+  }
+}
+
+async function saveState(
+  env: Env,
+  userId: string,
+  state: AState,
+): Promise<void> {
+  await env.NEWS_KV.put(stateKey(userId), JSON.stringify(state), {
+    expirationTtl: STATE_TTL_SECONDS,
+  });
+}
+
+export async function createResponse(
+  interaction: APIApplicationCommandInteraction,
+  env: Env,
+): Promise<APIInteractionResponse | null> {
+  if (interaction.data.type !== ApplicationCommandType.ChatInput) {
+    return null;
+  }
+  const options = interaction.data.options ?? [];
+  const aOpt = options.find((o) => o.name === 'a');
+  const spOpt = options.find((o) => o.name === 'a_sp');
+  const natureOpt = options.find((o) => o.name === 'a_nature');
+  const bOpt = options.find((o) => o.name === 'b');
+  if (bOpt?.type !== ApplicationCommandOptionType.String) {
+    return null;
+  }
+
+  const userId = getUserId(interaction);
+  const stored = userId ? await loadState(env, userId) : null;
+
+  const aNameIn =
+    aOpt?.type === ApplicationCommandOptionType.String ? aOpt.value : undefined;
+  const aSpIn =
+    spOpt?.type === ApplicationCommandOptionType.Integer
+      ? spOpt.value
+      : undefined;
+  const aNatureIn =
+    natureOpt?.type === ApplicationCommandOptionType.String
+      ? (natureOpt.value as NatureCode)
+      : undefined;
+
+  const aName = aNameIn ?? stored?.aName;
+  const aSp = aSpIn ?? stored?.aSp;
+  const aNatureCode = aNatureIn ?? stored?.aNature;
+
+  if (aName === undefined || aSp === undefined || aNatureCode === undefined) {
+    const missing = [
+      aName === undefined && '`a`',
+      aSp === undefined && '`a_sp`',
+      aNatureCode === undefined && '`a_nature`',
+    ]
+      .filter(Boolean)
+      .join(', ');
+    return {
+      type: InteractionResponseType.ChannelMessageWithSource,
+      data: {
+        content:
+          `初回利用は ${missing} も指定してくださいロト。次回からは \`b\` だけで計算できるようになるロト！`,
+        flags: MessageFlags.Ephemeral,
       },
-    ],
-  };
-}
+    };
+  }
 
-function buildChangeBModal(
-  aName: string,
-  aSp: number,
-  aNature: Nature,
-): APIModalInteractionResponseCallbackData {
-  const row: APIActionRowComponent<APIComponentInModalActionRow> = {
-    type: ComponentType.ActionRow,
-    components: [
-      {
-        type: ComponentType.TextInput,
-        custom_id: MODAL_B_NAME_INPUT,
-        label: 'ポケモンB名 (日本語正式名)',
-        style: TextInputStyle.Short,
-        required: true,
-        max_length: 32,
-      },
-    ],
-  };
-  return {
-    custom_id: `speedcompare:${SUBMIT_B_ACTION}:${aName}:${aSp}:${natureCode(aNature)}`,
-    title: `vs ${aName} (SP${aSp} ${aNature === 1.1 ? '↑' : aNature === 0.9 ? '↓' : '無'})`,
-    components: [row],
-  };
-}
+  const aNature = parseNature(aNatureCode);
+  const bName = bOpt.value;
+  console.log(
+    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName} (user=${userId})`,
+  );
 
-async function renderResult(
-  aName: string,
-  aSp: number,
-  aNature: Nature,
-  bName: string,
-): Promise<APIInteractionResponse> {
   const [aData, bData] = await Promise.all([
     searchPokemonByName(aName),
     searchPokemonByName(bName),
@@ -149,6 +182,15 @@ async function renderResult(
       },
     };
   }
+
+  if (userId) {
+    await saveState(env, userId, {
+      aName,
+      aSp,
+      aNature: aNatureCode,
+    });
+  }
+
   const vm = buildSpeedCompareViewModel({
     a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
     b: { name: bName, pokemon: bData },
@@ -158,88 +200,9 @@ async function renderResult(
     type: InteractionResponseType.ChannelMessageWithSource,
     data: {
       embeds: [embed],
-      components: [buildChangeBRow(aName, aSp, aNature)],
       flags: MessageFlags.Ephemeral,
     },
   };
-}
-
-export async function createResponse(
-  interaction: APIApplicationCommandInteraction,
-): Promise<APIInteractionResponse | null> {
-  if (interaction.data.type !== ApplicationCommandType.ChatInput) {
-    return null;
-  }
-  const options = interaction.data.options ?? [];
-  const aOpt = options.find((o) => o.name === 'a');
-  const spOpt = options.find((o) => o.name === 'a_sp');
-  const natureOpt = options.find((o) => o.name === 'a_nature');
-  const bOpt = options.find((o) => o.name === 'b');
-  if (
-    aOpt?.type !== ApplicationCommandOptionType.String ||
-    spOpt?.type !== ApplicationCommandOptionType.Integer ||
-    natureOpt?.type !== ApplicationCommandOptionType.String ||
-    bOpt?.type !== ApplicationCommandOptionType.String
-  ) {
-    return null;
-  }
-  const aName = aOpt.value;
-  const aSp = spOpt.value;
-  const aNature = parseNature(natureOpt.value);
-  const bName = bOpt.value;
-  console.log(
-    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
-  );
-  return renderResult(aName, aSp, aNature, bName);
-}
-
-export async function createComponentResponse(
-  interaction: APIMessageComponentInteraction,
-): Promise<ComponentResult | null> {
-  const [, action, aName, aSpStr, aNatureCode] =
-    interaction.data.custom_id.split(':');
-  if (action !== CHANGE_B_ACTION || !aName || !aSpStr || !aNatureCode) {
-    return null;
-  }
-  const aSp = Number(aSpStr);
-  const aNature = parseNature(aNatureCode);
-  return {
-    response: {
-      type: InteractionResponseType.Modal,
-      data: buildChangeBModal(aName, aSp, aNature),
-    },
-  };
-}
-
-export async function createModalSubmitResponse(
-  interaction: APIModalSubmitInteraction,
-): Promise<ComponentResult | null> {
-  const [, action, aName, aSpStr, aNatureCode] =
-    interaction.data.custom_id.split(':');
-  if (action !== SUBMIT_B_ACTION || !aName || !aSpStr || !aNatureCode) {
-    return null;
-  }
-  const aSp = Number(aSpStr);
-  const aNature = parseNature(aNatureCode);
-  let bName: string | undefined;
-  for (const row of interaction.data.components) {
-    if (row.type !== ComponentType.ActionRow) continue;
-    for (const comp of row.components) {
-      if (
-        comp.type === ComponentType.TextInput &&
-        comp.custom_id === MODAL_B_NAME_INPUT
-      ) {
-        bName = comp.value.trim();
-      }
-    }
-  }
-  if (!bName) {
-    return null;
-  }
-  console.log(
-    `[speedcompare:modal] a=${aName} sp=${aSp} nature=${aNature} b=${bName}`,
-  );
-  return { response: await renderResult(aName, aSp, aNature, bName) };
 }
 
 export async function createAutocompleteResponse(

--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -92,15 +92,27 @@ function emptyHistory(): History {
   return { a: [], aSp: [], b: [] };
 }
 
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string')
+    : [];
+}
+
+function toNumberArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is number => typeof v === 'number')
+    : [];
+}
+
 async function loadHistory(env: Env, userId: string): Promise<History> {
   const raw = await env.SPEEDCOMPARE_KV.get(historyKey(userId));
   if (!raw) return emptyHistory();
   try {
-    const parsed = JSON.parse(raw) as Partial<History>;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
     return {
-      a: Array.isArray(parsed.a) ? parsed.a : [],
-      aSp: Array.isArray(parsed.aSp) ? parsed.aSp : [],
-      b: Array.isArray(parsed.b) ? parsed.b : [],
+      a: toStringArray(parsed.a),
+      aSp: toNumberArray(parsed.aSp),
+      b: toStringArray(parsed.b),
     };
   } catch {
     return emptyHistory();
@@ -235,6 +247,7 @@ export async function createAutocompleteResponse(
     focused.type === ApplicationCommandOptionType.Integer &&
     focused.name === 'a_sp'
   ) {
+    // a_sp の候補は少数固定 (typical 6 + history 10) のため、入力値でのフィルタは行わず全件提示する
     const candidates = Array.from(
       new Set([...history.aSp, ...TYPICAL_SP_VALUES]),
     ).filter((n) => n >= 0 && n <= 32);

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import { Sentry } from './observability/types';
 export type Env = {
   SENTRY_DSN: string;
   NEWS_KV: KVNamespace;
+  SPEEDCOMPARE_KV: KVNamespace;
   DISCORD_APPLICATION_ID: string;
   DISCORD_TOKEN: string;
   DISCORD_PUBLIC_KEY: string;

--- a/src/discord/interactions.ts
+++ b/src/discord/interactions.ts
@@ -4,14 +4,13 @@ import {
   APIInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
-  APIModalSubmitInteraction,
   InteractionResponseType,
   InteractionType,
 } from 'discord-api-types/v10';
 import { verifyKey } from 'discord-interactions';
 import { MiddlewareHandler } from 'hono';
 import { ComponentFollowupContext, getCommandByName } from '../commands';
-import { HonoAppContext } from '../context';
+import { Env, HonoAppContext } from '../context';
 
 export type Interaction = APIInteraction;
 
@@ -39,6 +38,7 @@ export const verifyKeyMiddleware =
 // https://discord.com/developers/docs/interactions/receiving-and-responding#interactions
 export async function handleInteractionRequest(
   interaction: Interaction,
+  env: Env,
 ): Promise<InteractionResult> {
   console.log(
     `handleInteractionRequest: ${interaction.type} ${interaction.id}`,
@@ -48,39 +48,41 @@ export async function handleInteractionRequest(
       return { response: { type: InteractionResponseType.Pong } };
     case InteractionType.ApplicationCommand:
       return {
-        response: await handleApplicationCommandInteraction(interaction),
+        response: await handleApplicationCommandInteraction(interaction, env),
       };
     case InteractionType.ApplicationCommandAutocomplete:
       return {
-        response:
-          await handleApplicationCommandAutocompleteInteraction(interaction),
+        response: await handleApplicationCommandAutocompleteInteraction(
+          interaction,
+          env,
+        ),
       };
     case InteractionType.MessageComponent:
       return await handleMessageComponentInteraction(interaction);
-    case InteractionType.ModalSubmit:
-      return await handleModalSubmitInteraction(interaction);
   }
   throw new Error('Unknown interaction');
 }
 
 async function handleApplicationCommandInteraction(
   interaction: APIApplicationCommandInteraction,
+  env: Env,
 ): Promise<APIInteractionResponse | null> {
   const commandName = interaction.data.name;
   const command = getCommandByName(commandName);
   if (command) {
-    return await command.createResponse(interaction);
+    return await command.createResponse(interaction, env);
   }
   return { type: InteractionResponseType.Pong };
 }
 
 async function handleApplicationCommandAutocompleteInteraction(
   interaction: APIApplicationCommandAutocompleteInteraction,
+  env: Env,
 ): Promise<APIInteractionResponse | null> {
   const commandName = interaction.data.name;
   const command = getCommandByName(commandName);
   if (command && command.createAutocompleteResponse) {
-    return await command.createAutocompleteResponse(interaction);
+    return await command.createAutocompleteResponse(interaction, env);
   }
   return null;
 }
@@ -98,21 +100,5 @@ async function handleMessageComponentInteraction(
     }
   }
   console.warn(`No handler for component custom_id: ${customId}`);
-  return { response: null };
-}
-
-async function handleModalSubmitInteraction(
-  interaction: APIModalSubmitInteraction,
-): Promise<InteractionResult> {
-  const customId = interaction.data.custom_id;
-  const [namespace] = customId.split(':');
-  const command = namespace ? getCommandByName(namespace) : undefined;
-  if (command && command.createModalSubmitResponse) {
-    const result = await command.createModalSubmitResponse(interaction);
-    if (result) {
-      return result;
-    }
-  }
-  console.warn(`No handler for modal custom_id: ${customId}`);
   return { response: null };
 }

--- a/src/discord/interactions.ts
+++ b/src/discord/interactions.ts
@@ -4,13 +4,14 @@ import {
   APIInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
+  APIModalSubmitInteraction,
   InteractionResponseType,
   InteractionType,
 } from 'discord-api-types/v10';
 import { verifyKey } from 'discord-interactions';
 import { MiddlewareHandler } from 'hono';
 import { ComponentFollowupContext, getCommandByName } from '../commands';
-import { Env, HonoAppContext } from '../context';
+import { HonoAppContext } from '../context';
 
 export type Interaction = APIInteraction;
 
@@ -38,7 +39,6 @@ export const verifyKeyMiddleware =
 // https://discord.com/developers/docs/interactions/receiving-and-responding#interactions
 export async function handleInteractionRequest(
   interaction: Interaction,
-  env: Env,
 ): Promise<InteractionResult> {
   console.log(
     `handleInteractionRequest: ${interaction.type} ${interaction.id}`,
@@ -48,7 +48,7 @@ export async function handleInteractionRequest(
       return { response: { type: InteractionResponseType.Pong } };
     case InteractionType.ApplicationCommand:
       return {
-        response: await handleApplicationCommandInteraction(interaction, env),
+        response: await handleApplicationCommandInteraction(interaction),
       };
     case InteractionType.ApplicationCommandAutocomplete:
       return {
@@ -57,18 +57,19 @@ export async function handleInteractionRequest(
       };
     case InteractionType.MessageComponent:
       return await handleMessageComponentInteraction(interaction);
+    case InteractionType.ModalSubmit:
+      return await handleModalSubmitInteraction(interaction);
   }
   throw new Error('Unknown interaction');
 }
 
 async function handleApplicationCommandInteraction(
   interaction: APIApplicationCommandInteraction,
-  env: Env,
 ): Promise<APIInteractionResponse | null> {
   const commandName = interaction.data.name;
   const command = getCommandByName(commandName);
   if (command) {
-    return await command.createResponse(interaction, env);
+    return await command.createResponse(interaction);
   }
   return { type: InteractionResponseType.Pong };
 }
@@ -97,5 +98,21 @@ async function handleMessageComponentInteraction(
     }
   }
   console.warn(`No handler for component custom_id: ${customId}`);
+  return { response: null };
+}
+
+async function handleModalSubmitInteraction(
+  interaction: APIModalSubmitInteraction,
+): Promise<InteractionResult> {
+  const customId = interaction.data.custom_id;
+  const [namespace] = customId.split(':');
+  const command = namespace ? getCommandByName(namespace) : undefined;
+  if (command && command.createModalSubmitResponse) {
+    const result = await command.createModalSubmitResponse(interaction);
+    if (result) {
+      return result;
+    }
+  }
+  console.warn(`No handler for modal custom_id: ${customId}`);
   return { response: null };
 }

--- a/src/discord/interactions.ts
+++ b/src/discord/interactions.ts
@@ -4,14 +4,13 @@ import {
   APIInteraction,
   APIInteractionResponse,
   APIMessageComponentInteraction,
-  APIModalSubmitInteraction,
   InteractionResponseType,
   InteractionType,
 } from 'discord-api-types/v10';
 import { verifyKey } from 'discord-interactions';
 import { MiddlewareHandler } from 'hono';
 import { ComponentFollowupContext, getCommandByName } from '../commands';
-import { HonoAppContext } from '../context';
+import { Env, HonoAppContext } from '../context';
 
 export type Interaction = APIInteraction;
 
@@ -39,6 +38,7 @@ export const verifyKeyMiddleware =
 // https://discord.com/developers/docs/interactions/receiving-and-responding#interactions
 export async function handleInteractionRequest(
   interaction: Interaction,
+  env: Env,
 ): Promise<InteractionResult> {
   console.log(
     `handleInteractionRequest: ${interaction.type} ${interaction.id}`,
@@ -48,7 +48,7 @@ export async function handleInteractionRequest(
       return { response: { type: InteractionResponseType.Pong } };
     case InteractionType.ApplicationCommand:
       return {
-        response: await handleApplicationCommandInteraction(interaction),
+        response: await handleApplicationCommandInteraction(interaction, env),
       };
     case InteractionType.ApplicationCommandAutocomplete:
       return {
@@ -57,19 +57,18 @@ export async function handleInteractionRequest(
       };
     case InteractionType.MessageComponent:
       return await handleMessageComponentInteraction(interaction);
-    case InteractionType.ModalSubmit:
-      return await handleModalSubmitInteraction(interaction);
   }
   throw new Error('Unknown interaction');
 }
 
 async function handleApplicationCommandInteraction(
   interaction: APIApplicationCommandInteraction,
+  env: Env,
 ): Promise<APIInteractionResponse | null> {
   const commandName = interaction.data.name;
   const command = getCommandByName(commandName);
   if (command) {
-    return await command.createResponse(interaction);
+    return await command.createResponse(interaction, env);
   }
   return { type: InteractionResponseType.Pong };
 }
@@ -98,21 +97,5 @@ async function handleMessageComponentInteraction(
     }
   }
   console.warn(`No handler for component custom_id: ${customId}`);
-  return { response: null };
-}
-
-async function handleModalSubmitInteraction(
-  interaction: APIModalSubmitInteraction,
-): Promise<InteractionResult> {
-  const customId = interaction.data.custom_id;
-  const [namespace] = customId.split(':');
-  const command = namespace ? getCommandByName(namespace) : undefined;
-  if (command && command.createModalSubmitResponse) {
-    const result = await command.createModalSubmitResponse(interaction);
-    if (result) {
-      return result;
-    }
-  }
-  console.warn(`No handler for modal custom_id: ${customId}`);
   return { response: null };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,10 +29,7 @@ app.get('/', (c) => c.text('Hello!'));
  */
 app.post('/api/interactions', verifyKeyMiddleware(), async (c) => {
   const interaction = await c.req.json<Interaction>();
-  const { response, followup } = await handleInteractionRequest(
-    interaction,
-    c.env,
-  );
+  const { response, followup } = await handleInteractionRequest(interaction);
   if (followup && 'token' in interaction) {
     const discord = new DiscordApi(c.env.DISCORD_TOKEN);
     const ctx: Parameters<typeof followup>[0] = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,10 @@ app.get('/', (c) => c.text('Hello!'));
  */
 app.post('/api/interactions', verifyKeyMiddleware(), async (c) => {
   const interaction = await c.req.json<Interaction>();
-  const { response, followup } = await handleInteractionRequest(interaction);
+  const { response, followup } = await handleInteractionRequest(
+    interaction,
+    c.env,
+  );
   if (followup && 'token' in interaction) {
     const discord = new DiscordApi(c.env.DISCORD_TOKEN);
     const ctx: Parameters<typeof followup>[0] = {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,7 @@ name = "discord-rotom-bot"
 
 kv_namespaces = [
   {binding = "NEWS_KV", id = "696d3e3efb594ffcb9edd17c44a82566"},
+  {binding = "SPEEDCOMPARE_KV", id = "8c21dd1fd9844b12a131f5fe37f9e8b5"},
 ]
 
 # wrangler.toml (wrangler v3.88.0^)


### PR DESCRIPTION
## Summary

**目標**: 「Aを固定してBを切り替えながら素早さ比較したい」を実現する。

PR #87 の「🔁 Bを変えて再計算」ボタン + Modal はDiscord仕様上 autocomplete が効かず撤去。
代わりに **スラッシュコマンド オプションの autocomplete 候補を直近使用履歴で上位ソート** する方式を採用。ユーザーは毎回 A/B を明示選択しつつ、履歴の上位候補を1キーで再利用できる。

## 変更点

### speedcompare
- `/speedcompare` は従来通り `a / a_sp / a_nature / b` を required で受ける
- `a`, `a_sp`, `b` の autocomplete 候補を **直近使用履歴** が上位に来るよう並び替え（重複なし）
  - `a` / `b`: `getAllPokemonNames` の検索結果を history で昇格
  - `a_sp`: 履歴 + typical values `[0, 4, 12, 20, 28, 32]` を合成 → history で昇格
- 実行時に `{a, aSp, b}` の直近10件を `SPEEDCOMPARE_KV` に `sc:history:{user_id}` で保存（TTL 30日）
- `a_nature` は choices 3種のみのため履歴なし

### 関心分離
- 新規専用 `SPEEDCOMPARE_KV` namespace を追加（NEWS_KV とは分離）
- `wrangler.toml` に binding を追加: `id = "8c21dd1fd9844b12a131f5fe37f9e8b5"`（ユーザー作成済み）

### インフラ
- `Command.createResponse` / `createAutocompleteResponse` のシグネチャに `env: Env` を追加
- `interactions.ts` で env を propagate
- PR #87 の ModalSubmit ディスパッチおよび `Command.createModalSubmitResponse` 型を削除

### 破棄
- PR #87 で入れた change-b ボタン / Modal / ModalSubmit 関連コードは全撤去
- PR #88 の初版コミット (bb38bc6: A optional化 + NEWS_KV流用) は revert 済み

## UX

1. 初回: `/speedcompare a:<A> a_sp:<SP> a_nature:<性格> b:<B>` を通常入力
2. 2回目以降:
   - `a:` にフォーカス → 履歴先頭に前回のA → Enterで即選択
   - `a_sp:` → 前回のSPが先頭 → Enterで即選択
   - `a_nature:` → choices 3択
   - `b:` → 履歴先頭に直近のB → 切り替えたいポケモンを入力/選択
3. 複数のAを使い分け可能（履歴10件まで、直近使用順）

## Test plan

- [x] `pnpm test` (56 tests passed)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] デプロイ後、`/speedcompare` を実行
- [ ] 2回目の `a:` autocomplete に前回のAが先頭で出ることを確認
- [ ] 履歴10件以上になった時の上位表示が期待通りか確認
