### PR TITLE
feat(speedcompare): share button + A rank option

### DIFF
--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -1,15 +1,21 @@
 import {
+  APIActionRowComponent,
   APIApplicationCommandAutocompleteInteraction,
   APIApplicationCommandAutocompleteResponse,
   APIApplicationCommandInteraction,
+  APIComponentInMessageActionRow,
   APIInteraction,
   APIInteractionResponse,
+  APIMessageComponentInteraction,
   ApplicationCommandOptionType,
   ApplicationCommandType,
+  ButtonStyle,
+  ComponentType,
   InteractionResponseType,
   MessageFlags,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
+import { ComponentResult } from '.';
 import { Env } from '../context';
 import { getAllPokemonNames, searchPokemonByName } from '../pokeinfo';
 import type { Nature } from '../speedcompare/compare';
@@ -70,6 +76,27 @@ export default {
       type: ApplicationCommandOptionType.String,
       required: true,
       autocomplete: true,
+    },
+    {
+      name: 'a_rank',
+      description: 'Aの能力ランク補正 (-6〜+6、省略時は0)',
+      type: ApplicationCommandOptionType.Integer,
+      required: false,
+      choices: [
+        { name: '-6', value: -6 },
+        { name: '-5', value: -5 },
+        { name: '-4', value: -4 },
+        { name: '-3', value: -3 },
+        { name: '-2 (まひ相当)', value: -2 },
+        { name: '-1', value: -1 },
+        { name: '±0', value: 0 },
+        { name: '+1 (スカーフ相当)', value: 1 },
+        { name: '+2 (おいかぜ相当)', value: 2 },
+        { name: '+3', value: 3 },
+        { name: '+4', value: 4 },
+        { name: '+5', value: 5 },
+        { name: '+6', value: 6 },
+      ],
     },
   ],
 } satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
@@ -154,6 +181,7 @@ export async function createResponse(
   const spOpt = options.find((o) => o.name === 'a_sp');
   const natureOpt = options.find((o) => o.name === 'a_nature');
   const bOpt = options.find((o) => o.name === 'b');
+  const rankOpt = options.find((o) => o.name === 'a_rank');
   if (
     aOpt?.type !== ApplicationCommandOptionType.String ||
     spOpt?.type !== ApplicationCommandOptionType.Integer ||
@@ -166,9 +194,11 @@ export async function createResponse(
   const aSp = spOpt.value;
   const aNature = parseNature(natureOpt.value);
   const bName = bOpt.value;
+  const aRank =
+    rankOpt?.type === ApplicationCommandOptionType.Integer ? rankOpt.value : 0;
   const userId = getUserId(interaction);
   console.log(
-    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} b=${bName} (user=${userId})`,
+    `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} rank=${aRank} b=${bName} (user=${userId})`,
   );
 
   const [aData, bData] = await Promise.all([
@@ -199,7 +229,7 @@ export async function createResponse(
   }
 
   const vm = buildSpeedCompareViewModel({
-    a: { name: aName, pokemon: aData, sp: aSp, nature: aNature },
+    a: { name: aName, pokemon: aData, sp: aSp, nature: aNature, rank: aRank },
     b: { name: bName, pokemon: bData },
   });
   const embed = formatSpeedCompareEmbed(vm);
@@ -207,7 +237,72 @@ export async function createResponse(
     type: InteractionResponseType.ChannelMessageWithSource,
     data: {
       embeds: [embed],
+      components: [buildShareActionRow()],
       flags: MessageFlags.Ephemeral,
+    },
+  };
+}
+
+const SHARE_ACTION = 'share';
+
+function buildShareActionRow(): APIActionRowComponent<APIComponentInMessageActionRow> {
+  return {
+    type: ComponentType.ActionRow,
+    components: [
+      {
+        type: ComponentType.Button,
+        style: ButtonStyle.Primary,
+        label: 'チャンネルにシェア',
+        custom_id: `speedcompare:${SHARE_ACTION}`,
+      },
+    ],
+  };
+}
+
+export async function createComponentResponse(
+  interaction: APIMessageComponentInteraction,
+): Promise<ComponentResult | null> {
+  const [, action] = interaction.data.custom_id.split(':');
+  if (action !== SHARE_ACTION) {
+    return null;
+  }
+  const embeds = interaction.message.embeds;
+  if (!embeds || embeds.length === 0) {
+    return {
+      response: {
+        type: InteractionResponseType.UpdateMessage,
+        data: {
+          content: 'シェアできる内容がなかったロト...',
+          embeds: [],
+          components: [],
+        },
+      },
+    };
+  }
+  return {
+    response: {
+      type: InteractionResponseType.UpdateMessage,
+      data: {
+        content: 'チャンネルにシェアしたロト！',
+        embeds: [],
+        components: [],
+      },
+    },
+    followup: async ({ applicationId, interactionToken, discord }) => {
+      try {
+        await discord.postInteractionFollowup(applicationId, interactionToken, {
+          embeds,
+        });
+      } catch (e) {
+        await discord
+          .patchOriginalInteractionResponse(applicationId, interactionToken, {
+            content: 'シェアに失敗したロト...',
+            embeds,
+            components: [buildShareActionRow()],
+          })
+          .catch((e2) => console.error('Rollback failed:', e2));
+        throw e;
+      }
     },
   };
 }

--- a/src/speedcompare/view-model.ts
+++ b/src/speedcompare/view-model.ts
@@ -12,6 +12,8 @@ export type AInput = {
   pokemon: Pokemon;
   sp: number;
   nature: Nature;
+  /** Aの能力ランク補正 (-6〜+6、省略時は0) */
+  rank?: number;
 };
 
 export type BInput = {
@@ -44,12 +46,19 @@ function formatNature(nature: Nature): string {
   return '無補正';
 }
 
+function formatRankSuffix(rank: number): string {
+  if (rank === 0) return '';
+  if (rank > 0) return ` ランク+${rank}`;
+  return ` ランク${rank}`;
+}
+
 export function buildSpeedCompareViewModel(input: {
   a: AInput;
   b: BInput;
 }): SpeedCompareViewModel {
   const { a, b } = input;
-  const aSpeed = effectiveSpeed(a.pokemon.baseStats.S, a.sp, a.nature, 0);
+  const aRank = a.rank ?? 0;
+  const aSpeed = effectiveSpeed(a.pokemon.baseStats.S, a.sp, a.nature, aRank);
   const bBase = b.pokemon.baseStats.S;
   const bActuals = calcActuals('S', bBase) as [number, number, number, number];
 
@@ -60,7 +69,7 @@ export function buildSpeedCompareViewModel(input: {
 
   return {
     aName: a.name,
-    aConfig: `SP${a.sp} ${formatNature(a.nature)}`,
+    aConfig: `SP${a.sp} ${formatNature(a.nature)}${formatRankSuffix(aRank)}`,
     aBase: a.pokemon.baseStats.S,
     aSpeed,
     bName: b.name,


### PR DESCRIPTION
## Summary

- pokeinfo と同様に、speedcompare の ephemeral 結果メッセージから「チャンネルにシェア」できるボタンを追加
- `/speedcompare` に **A側の能力ランク補正** オプション (`a_rank`) を追加（-6〜+6、省略時は0）

## 変更点

### シェアボタン
- 結果Embedに `Primary` スタイルの「チャンネルにシェア」ボタンを付与 (`custom_id: speedcompare:share`)
- ボタン押下時:
  - Ephemeral メッセージを「チャンネルにシェアしたロト！」に UpdateMessage
  - `interaction.message.embeds` をそのまま followup で public チャンネルに投稿（再計算なし）
  - 投稿失敗時は PATCH で rollback（pokeinfo と同パターン）

### A rank オプション
- `a_rank`: Integer + choices（13値、`±0` デフォルト）、`-2 (まひ相当)` `+1 (スカーフ相当)` `+2 (おいかぜ相当)` のラベルで補正換算ヒントも表示
- view-model の `AInput` に `rank?: number` を追加、`effectiveSpeed(base, sp, nature, rank)` で aSpeed に反映
- `aConfig` 表示には rank が 0以外の時のみ `ランク+1` などのサフィックスを付与

## Test plan

- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] デプロイ後、`/speedcompare` 結果に「チャンネルにシェア」ボタンが出ることを確認
- [ ] シェアボタン押下 → チャンネルに公開投稿 + ephemeral はシェア完了表示になることを確認
- [ ] `a_rank` に `+1` を指定した結果が「スカーフ持ち」相当になっていることを確認