### PR TITLE
fix(speedcompare): surface a_rank between a_nature and b

### DIFF
--- a/src/commands/speedcompare.ts
+++ b/src/commands/speedcompare.ts
@@ -70,33 +70,33 @@ export default {
       ],
     },
     {
-      name: 'b',
-      description:
-        '仮想敵ポケモンB（直近使用したポケモンが上位に表示されます）',
-      type: ApplicationCommandOptionType.String,
-      required: true,
-      autocomplete: true,
-    },
-    {
       name: 'a_rank',
-      description: 'Aの能力ランク補正 (-6〜+6、省略時は0)',
+      description: 'Aの能力ランク補正',
       type: ApplicationCommandOptionType.Integer,
-      required: false,
+      required: true,
       choices: [
-        { name: '-6', value: -6 },
-        { name: '-5', value: -5 },
-        { name: '-4', value: -4 },
-        { name: '-3', value: -3 },
-        { name: '-2 (まひ相当)', value: -2 },
-        { name: '-1', value: -1 },
-        { name: '±0', value: 0 },
+        { name: '±0 (補正なし)', value: 0 },
         { name: '+1 (スカーフ相当)', value: 1 },
         { name: '+2 (おいかぜ相当)', value: 2 },
         { name: '+3', value: 3 },
         { name: '+4', value: 4 },
         { name: '+5', value: 5 },
         { name: '+6', value: 6 },
+        { name: '-1', value: -1 },
+        { name: '-2 (まひ相当)', value: -2 },
+        { name: '-3', value: -3 },
+        { name: '-4', value: -4 },
+        { name: '-5', value: -5 },
+        { name: '-6', value: -6 },
       ],
+    },
+    {
+      name: 'b',
+      description:
+        '仮想敵ポケモンB（直近使用したポケモンが上位に表示されます）',
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: true,
     },
   ],
 } satisfies RESTPostAPIChatInputApplicationCommandsJSONBody;
@@ -180,12 +180,13 @@ export async function createResponse(
   const aOpt = options.find((o) => o.name === 'a');
   const spOpt = options.find((o) => o.name === 'a_sp');
   const natureOpt = options.find((o) => o.name === 'a_nature');
-  const bOpt = options.find((o) => o.name === 'b');
   const rankOpt = options.find((o) => o.name === 'a_rank');
+  const bOpt = options.find((o) => o.name === 'b');
   if (
     aOpt?.type !== ApplicationCommandOptionType.String ||
     spOpt?.type !== ApplicationCommandOptionType.Integer ||
     natureOpt?.type !== ApplicationCommandOptionType.String ||
+    rankOpt?.type !== ApplicationCommandOptionType.Integer ||
     bOpt?.type !== ApplicationCommandOptionType.String
   ) {
     return null;
@@ -193,9 +194,8 @@ export async function createResponse(
   const aName = aOpt.value;
   const aSp = spOpt.value;
   const aNature = parseNature(natureOpt.value);
+  const aRank = rankOpt.value;
   const bName = bOpt.value;
-  const aRank =
-    rankOpt?.type === ApplicationCommandOptionType.Integer ? rankOpt.value : 0;
   const userId = getUserId(interaction);
   console.log(
     `[speedcompare] a=${aName} sp=${aSp} nature=${aNature} rank=${aRank} b=${bName} (user=${userId})`,


### PR DESCRIPTION
## Summary

`a_rank` オプションが `b` の後ろに配置されて埋もれて視認性が悪いという指摘を受けての修正。Discord API 仕様では optional option は全 required option の後ろにしか置けないため、`a_rank` を **required** に変更して順序を Aグループ→B の自然な並びに整理する。

## 変更点

- options 並び: `a / a_sp / a_nature / b / (a_rank)` → `a / a_sp / a_nature / a_rank / b`
- `a_rank` を `required: true` に
- choices 並び: `±0 (補正なし)` を先頭にして実質的なデフォルト値として明示
- 履歴保持件数 `HISTORY_LIMIT = 10` は維持（変更なし）

## Test plan

- [x] `pnpm test` / `pnpm typecheck` / `pnpm lint`
- [ ] デプロイ後、Discord で `/speedcompare` の option順序が A系まとまり → b になっていることを確認
- [ ] `a_rank` が必須選択肢として見えていることを確認