### PR TITLE
chore: pokemon data 更新を単一ブランチに集約

### DIFF
--- a/.github/workflows/update-pokemon-data.yml
+++ b/.github/workflows/update-pokemon-data.yml
@@ -32,16 +32,19 @@ jobs:
         id: diff
         run: |
           git diff --exit-code src/pokeinfo/data.generated.json && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
-      - name: Create PR
+      - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          BRANCH="chore/update-pokemon-data-$(date +%Y%m%d%H%M%S)"
-          git checkout -b "$BRANCH"
+          BRANCH="chore/update-pokemon-data"
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          git checkout -B "$BRANCH"
           git add vendor/pokedex src/pokeinfo/data.generated.json src/pokeinfo/yakkun-map.json
           git commit -m "chore: update pokemon data from towakey/pokedex"
-          git push origin "$BRANCH"
-          gh pr create --title "chore: update pokemon data" --body "towakey/pokedex の最新データで data.generated.json を更新。"
+          git push --force-with-lease origin "$BRANCH"
+          if ! gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr create --title "chore: update pokemon data" --body "towakey/pokedex の最新データで data.generated.json を更新。"
+          fi


### PR DESCRIPTION
## Summary

- `update-pokemon-data.yml` の PR 作成ステップでブランチ命名を `chore/update-pokemon-data-<timestamp>` → `chore/update-pokemon-data` (固定) に変更
- 差分があれば `git push --force-with-lease` で固定ブランチを上書き
- 既存 PR が open なら自動的に新コミットが流れ込み、無ければ `gh pr create` で新規作成
- 結果: 未マージの古い PR が累積する問題を解消（常時 0 または 1 件）

cron を日次に変更した #121 と組み合わせると、毎日チェックして必要な時だけ 1 件の PR が更新される運用になる。

## Test plan

- [ ] CI (format/lint/typecheck/test) が green
- [ ] マージ後の workflow_dispatch 1 回目: `chore/update-pokemon-data` ブランチ生成 + PR 作成
- [ ] 2 回目以降: 同 PR にコミットが追加（新規 PR は立たない）
- [ ] 既存の累積 PR (#83, #92, #95, #100, #105, #108, #111, #114, #118) はこの PR の対象外。別途手動 close を推奨

## Notes

`--force-with-lease` はボット専用ブランチに対する上書きで、人間の手コミットを破壊するリスクはない。


---
_Generated by [Claude Code](https://claude.ai/code/session_01MvcA9rRNketkJysCohHWru)_